### PR TITLE
fix: 카카오일 때만 카카오 sdk의 로그아웃 호출하도록 수정

### DIFF
--- a/lib/features/auth/data/models/platform.dart
+++ b/lib/features/auth/data/models/platform.dart
@@ -1,0 +1,4 @@
+enum Platform {
+  apple,
+  kakao,
+}

--- a/lib/features/auth/data/models/user_model.dart
+++ b/lib/features/auth/data/models/user_model.dart
@@ -1,11 +1,5 @@
-enum Platform {
-  apple,
-  kakao,
-}
-
 class UserModel {
   final String name;
-  final Platform platform; // 로그인한 플랫폼
 
-  UserModel({required this.name, required this.platform});
+  UserModel({required this.name});
 }

--- a/lib/features/auth/presentation/viewmodels/auth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/auth_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pravo_client/features/auth/data/models/platform.dart';
 
 final authProvider =
     ChangeNotifierProvider<AuthNotifier>((ref) => AuthNotifier(ref: ref));
@@ -10,6 +11,7 @@ class AuthNotifier extends ChangeNotifier {
   final _secureStorage = const FlutterSecureStorage();
   bool _isTokenRead = false;
   String? _token;
+  Platform? _platform;
 
   bool get isTokenRead => _isTokenRead;
 
@@ -32,9 +34,10 @@ class AuthNotifier extends ChangeNotifier {
   }
 
   // 토큰 저장 로직
-  Future<void> login(String newToken) async {
+  Future<void> login(String newToken, Platform newPlatform) async {
     await _secureStorage.write(key: 'token', value: newToken);
     _token = newToken;
+    _platform = newPlatform;
     notifyListeners();
   }
 
@@ -42,6 +45,7 @@ class AuthNotifier extends ChangeNotifier {
   Future<void> logout() async {
     await _secureStorage.delete(key: 'token');
     _token = null;
+    _platform = null;
     notifyListeners();
   }
 }

--- a/lib/features/auth/presentation/viewmodels/auth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/auth_provider.dart
@@ -19,6 +19,10 @@ class AuthNotifier extends ChangeNotifier {
     _readTokenFromStorage(); // 초기화 시 토큰 확인
   }
 
+  Platform? getPlatform() {
+    return _platform;
+  }
+
   // 저장소에 저장된 토큰 확인
   Future<void> _readTokenFromStorage() async {
     _token = await _secureStorage.read(key: 'token');

--- a/lib/features/auth/presentation/viewmodels/auth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/auth_provider.dart
@@ -9,45 +9,53 @@ final authProvider =
 class AuthNotifier extends ChangeNotifier {
   final Ref ref;
   final _secureStorage = const FlutterSecureStorage();
-  bool _isTokenRead = false;
+  bool _isCredentialsLoaded = false;
   String? _token;
   Platform? _platform;
 
-  bool get isTokenRead => _isTokenRead;
-
   AuthNotifier({required this.ref}) {
-    _readTokenFromStorage(); // 초기화 시 토큰 확인
+    _loadCredentialsFromStorage(); // 초기화 시 토큰 확인
   }
 
   Platform? getPlatform() {
     return _platform;
   }
 
-  // 저장소에 저장된 토큰 확인
-  Future<void> _readTokenFromStorage() async {
+  /// 저장소에 저장된 정보 확인
+  Future<void> _loadCredentialsFromStorage() async {
     _token = await _secureStorage.read(key: 'token');
-    _isTokenRead = true;
+
+    String? platform = await _secureStorage.read(key: 'platform');
+    if (platform == Platform.apple.name) {
+      _platform = Platform.apple;
+    } else if (platform == Platform.kakao.name) {
+      _platform = Platform.kakao;
+    }
+
+    _isCredentialsLoaded = true;
     notifyListeners();
   }
 
   Future<bool> isTokenValid() async {
-    if (!_isTokenRead) {
-      await _readTokenFromStorage();
+    if (!_isCredentialsLoaded) {
+      await _loadCredentialsFromStorage();
     }
     return _token != null;
   }
 
-  // 토큰 저장 로직
+  /// 로그인
   Future<void> login(String newToken, Platform newPlatform) async {
     await _secureStorage.write(key: 'token', value: newToken);
+    await _secureStorage.write(key: 'platform', value: newPlatform.name);
     _token = newToken;
     _platform = newPlatform;
     notifyListeners();
   }
 
-  // 토큰 삭제 로직
+  /// 로그아웃
   Future<void> logout() async {
     await _secureStorage.delete(key: 'token');
+    await _secureStorage.delete(key: 'platform');
     _token = null;
     _platform = null;
     notifyListeners();

--- a/lib/features/auth/presentation/viewmodels/user_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/user_provider.dart
@@ -8,14 +8,6 @@ final userProvider = StateNotifierProvider<UserStateNotifer, UserModel?>(
 class UserStateNotifer extends StateNotifier<UserModel?> {
   UserStateNotifer() : super(null);
 
-  void appleLogin({required String name}) {
-    state = UserModel(name: name, platform: Platform.apple);
-  }
-
-  void kakaoLogin({required String name}) {
-    state = UserModel(name: name, platform: Platform.kakao);
-  }
-
   void logout() {
     state = null;
   }

--- a/lib/features/auth/presentation/widgets/apple_login_button_widget.dart
+++ b/lib/features/auth/presentation/widgets/apple_login_button_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/auth/data/models/platform.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/auth/presentation/widgets/social_login_button_widget.dart';
@@ -17,7 +18,7 @@ class AppleLoginButtonWidget extends ConsumerWidget {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('애플 로그인 성공')),
       );
-      await authNotifier.login(identityToken); // 로그인 성공 시 토큰 저장
+      await authNotifier.login(identityToken, Platform.apple); // 로그인 성공 시 토큰 저장
     }
 
     void handleLoginError(

--- a/lib/features/auth/presentation/widgets/kakao_login_button_widget.dart
+++ b/lib/features/auth/presentation/widgets/kakao_login_button_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:pravo_client/features/auth/data/models/platform.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/auth/presentation/widgets/social_login_button_widget.dart';
 
@@ -20,7 +21,10 @@ class KakaoLoginButtonWidget extends ConsumerWidget {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(successMessage)),
       );
-      await authNotifier.login(token.accessToken); // 로그인 성공 시 토큰 저장
+      await authNotifier.login(
+        token.accessToken,
+        Platform.kakao,
+      ); // 로그인 성공 시 토큰 저장
     }
 
     // 로그인 오류 처리 함수

--- a/lib/features/setting/presentation/widgets/text_buttons_widget.dart
+++ b/lib/features/setting/presentation/widgets/text_buttons_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:pravo_client/features/auth/data/models/platform.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/text_button_widget.dart';
 
@@ -13,16 +14,11 @@ class TextButtonsWidget extends ConsumerWidget {
     Future<void> logout() async {
       final authNotifier = ref.read(authProvider);
 
-      try {
+      if (authNotifier.getPlatform() == Platform.kakao) {
         await UserApi.instance.logout();
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('로그아웃 성공, SDK에서 토큰 삭제')),
-        );
-        await authNotifier.logout(); // 로그아웃 시 AuthNotifier의 상태 업데이트
-      } catch (error) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('카카오톡으로 로그인 실패 $error')));
       }
+
+      await authNotifier.logout();
     }
 
     return Column(


### PR DESCRIPTION
## 📝 개요
카카오일 때만 카카오 sdk의 로그아웃 호출하도록 수정


## 🪐 작업 내용

- [ ] Platform을 user_model.dart 가 아닌 platform.dart에 저장 
- [ ] auth_provider 통해서 platform 상태 관리
- [ ] 카카오일 때만 카카오 sdk의 로그아웃 호출하도록 수정

## 🛰️ 이슈 번호

#30 

## 📚 참고 자료
