### PR TITLE
fix: Dio의 BaseUrl 프라보 서버 호스트로 설정

### DIFF
--- a/lib/features/core/dio/dio_provider.dart
+++ b/lib/features/core/dio/dio_provider.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio();
@@ -12,6 +13,7 @@ final dioProvider = Provider<Dio>((ref) {
     ),
   );
   dio.options = BaseOptions(
+    baseUrl: dotenv.env['PRAVO_BASE_URL']!,
     sendTimeout: const Duration(seconds: 5),
   );
   return dio;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,7 +263,7 @@ packages:
     source: hosted
     version: "2.3.7"
   dio:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: dio
       sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"


### PR DESCRIPTION
## 📝 개요
Dio의 BaseUrl 프라보 서버 호스트로 설정

## 🪐 작업 내용
Dio의 BaseUrl 프라보 서버 호스트로 설정

## 🛰️ 이슈 번호

## 📚 참고 자료

`.env` 파일에 `PRAVO_BASE_URL=https://www.pravo.p-e.kr/` 추가 필요합니당