### PR TITLE
feat: 약속 목록 조회 API 연동

### DIFF
--- a/lib/features/core/presentation/widgets/promise_widget.dart
+++ b/lib/features/core/presentation/widgets/promise_widget.dart
@@ -5,8 +5,21 @@ import 'package:pravo_client/assets/constants.dart';
 
 class PromiseWidget extends StatelessWidget {
   final int promiseId;
+  final String? promiseName; // FIXME: 수정할 코드가 많아져서 임시로 nullable하게 처리 했음!!
+  final String? organizerName;
+  final String? location;
+  final DateTime? promiseDate;
+  final String? organizerProfileImageUrl;
 
-  const PromiseWidget({super.key, required this.promiseId});
+  const PromiseWidget({
+    super.key,
+    required this.promiseId,
+    this.promiseName,
+    this.organizerName,
+    this.location,
+    this.promiseDate,
+    this.organizerProfileImageUrl,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -27,28 +40,33 @@ class PromiseWidget extends StatelessWidget {
                   children: [
                     CircleAvatar(
                       backgroundColor: kAvatarBackgroundColor,
-                      child: Padding(
-                        padding: const EdgeInsets.all(6),
-                        child: Image.asset(
-                          'assets/images/avocado.png',
-                        ),
-                      ),
+                      backgroundImage: organizerProfileImageUrl != null
+                          ? NetworkImage(organizerProfileImageUrl!)
+                          : null,
+                      child: organizerProfileImageUrl == null
+                          ? Padding(
+                              padding: const EdgeInsets.all(6),
+                              child: Image.asset(
+                                'assets/images/avocado.png',
+                              ),
+                            )
+                          : null,
                     ),
                     Container(
                       margin: const EdgeInsets.only(left: 12),
-                      child: const Column(
+                      child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            '아보카도 농장 체험',
-                            style: TextStyle(
+                            promiseName ?? '아보카도 농장 체험',
+                            style: const TextStyle(
                               fontSize: 16,
                               fontWeight: FontWeight.w600,
                             ),
                           ),
                           Text(
-                            'Mr. Avocado',
-                            style: TextStyle(
+                            organizerName ?? 'Mr. Avocado',
+                            style: const TextStyle(
                               fontSize: 14,
                             ),
                           ),
@@ -69,30 +87,32 @@ class PromiseWidget extends StatelessWidget {
               margin: const EdgeInsets.only(
                 top: 16,
               ),
-              child: const Row(
+              child: Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
                   Text(
-                    '아보카도 농장',
-                    style: TextStyle(
+                    location ?? '아보카도 농장',
+                    style: const TextStyle(
                       fontSize: 14,
                     ),
                   ),
-                  SizedBox(
+                  const SizedBox(
                     width: 4,
                   ),
-                  Text(
+                  const Text(
                     '•',
                     style: TextStyle(
                       fontSize: 14,
                     ),
                   ),
-                  SizedBox(
+                  const SizedBox(
                     width: 4,
                   ),
                   Text(
-                    '10월 1일 12:00AM',
-                    style: TextStyle(
+                    promiseDate != null
+                        ? '${promiseDate!.month}월 ${promiseDate!.day}일 ${promiseDate!.hour}:${promiseDate!.minute.toString().padLeft(2, '0')}'
+                        : '10월 1일 12:00AM',
+                    style: const TextStyle(
                       fontSize: 14,
                     ),
                   ),

--- a/lib/features/promises/data/models/promise_model.dart
+++ b/lib/features/promises/data/models/promise_model.dart
@@ -1,0 +1,31 @@
+class PromiseModel {
+  final int id;
+  final String name;
+  final DateTime promiseDate;
+  final String location;
+  final String status;
+  final String organizerName;
+  final String? organizerProfileImageUrl;
+
+  PromiseModel({
+    required this.id,
+    required this.name,
+    required this.promiseDate,
+    required this.location,
+    required this.status,
+    required this.organizerName,
+    this.organizerProfileImageUrl,
+  });
+
+  factory PromiseModel.fromJson(Map<String, dynamic> json) {
+    return PromiseModel(
+      id: json['id'],
+      name: json['name'],
+      promiseDate: DateTime.parse(json['promiseDate']),
+      location: json['location'],
+      status: json['status'],
+      organizerName: json['organizerName'],
+      organizerProfileImageUrl: json['organizerProfileImageUrl'],
+    );
+  }
+}

--- a/lib/features/promises/data/repository/promise_repository.dart
+++ b/lib/features/promises/data/repository/promise_repository.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart' hide Headers;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/core/dio/dio_provider.dart';
+import 'package:pravo_client/features/promises/data/models/promise_model.dart';
+import 'package:pravo_client/features/promises/domain/entity/promise.dart';
+
+final promisesRepositoryProvider = Provider<PromisesRepository>((ref) {
+  return PromisesRepository(ref.read(dioProvider));
+});
+
+class PromisesRepository {
+  final Dio dio;
+
+  PromisesRepository(this.dio);
+
+  Future<List<Promise>> getPromises() async {
+    final response = await dio.get('/api/promises');
+    return (response.data as List)
+        .map((promise) => PromiseModel.fromJson(promise))
+        .map(
+          (model) => Promise(
+            id: model.id,
+            name: model.name,
+            promiseDate: model.promiseDate,
+            location: model.location,
+            status: model.status,
+            organizerName: model.organizerName,
+            organizerProfileImageUrl: model.organizerProfileImageUrl,
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/features/promises/data/repository/promise_repository.dart
+++ b/lib/features/promises/data/repository/promise_repository.dart
@@ -13,8 +13,79 @@ class PromisesRepository {
 
   PromisesRepository(this.dio);
 
-  Future<List<Promise>> getPromises() async {
-    final response = await dio.get('/api/promises');
+  Future<List<Promise>> getUpcomingPromises(DateTime startDate) async {
+    return Future.delayed(const Duration(milliseconds: 500), () {
+      return [
+        Promise(
+          id: 1,
+          name: '친구와 저녁식사',
+          promiseDate: DateTime.now().add(const Duration(days: 5)),
+          location: '서울 강남구',
+          status: 'READY',
+          organizerName: 'Alice',
+          organizerProfileImageUrl:
+              'https://avatars.githubusercontent.com/u/76519535?v=4',
+        ),
+        Promise(
+          id: 2,
+          name: '회사 회식',
+          promiseDate: DateTime.now().add(const Duration(days: 10)),
+          location: '서울 마포구',
+          status: 'CONFIRMED',
+          organizerName: 'Bob',
+          organizerProfileImageUrl:
+              'https://avatars.githubusercontent.com/u/90690578?v=4',
+        ),
+      ];
+    });
+
+    // FIXME: API 개발 완료되면 아래 코드로 대체할 것
+    // final response = await dio.get(
+    //   '/api/promises',
+    //   queryParameters: {
+    //     'startedAt': startDate.toIso8601String().split('T').first,
+    //   },
+    // );
+    // return _mapResponseToPromises(response);
+  }
+
+  Future<List<Promise>> getPastPromises(DateTime endDate) async {
+    return Future.delayed(const Duration(milliseconds: 500), () {
+      return [
+        Promise(
+          id: 3,
+          name: '가족 모임',
+          promiseDate: DateTime.now().subtract(const Duration(days: 3)),
+          location: '부산 해운대',
+          status: 'COMPLETED',
+          organizerName: 'Charlie',
+          organizerProfileImageUrl:
+              'https://avatars.githubusercontent.com/u/134353209?v=4',
+        ),
+        Promise(
+          id: 4,
+          name: '운동 모임',
+          promiseDate: DateTime.now().subtract(const Duration(days: 7)),
+          location: '서울 종로구',
+          status: 'COMPLETED',
+          organizerName: 'Dave',
+          organizerProfileImageUrl:
+              'https://avatars.githubusercontent.com/u/31067658?v=4',
+        ),
+      ];
+    });
+
+    // FIXME: API 개발 완료되면 아래 코드로 대체할 것
+    // final response = await dio.get(
+    //   '/api/promises',
+    //   queryParameters: {
+    //     'endedAt': endDate.toIso8601String().split('T').first,
+    //   },
+    // );
+    // return _mapResponseToPromises(response);
+  }
+
+  List<Promise> _mapResponseToPromises(Response response) {
     return (response.data as List)
         .map((promise) => PromiseModel.fromJson(promise))
         .map(

--- a/lib/features/promises/domain/entity/promise.dart
+++ b/lib/features/promises/domain/entity/promise.dart
@@ -1,0 +1,19 @@
+class Promise {
+  final int id;
+  final String name;
+  final DateTime promiseDate;
+  final String location;
+  final String status;
+  final String organizerName;
+  final String? organizerProfileImageUrl;
+
+  Promise({
+    required this.id,
+    required this.name,
+    required this.promiseDate,
+    required this.location,
+    required this.status,
+    required this.organizerName,
+    this.organizerProfileImageUrl,
+  });
+}

--- a/lib/features/promises/domain/usecase/get_promises_usecase.dart
+++ b/lib/features/promises/domain/usecase/get_promises_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:pravo_client/features/promises/data/repository/promise_repository.dart';
+import 'package:pravo_client/features/promises/domain/entity/promise.dart';
+
+class GetPromisesUseCase {
+  final PromisesRepository repository;
+
+  GetPromisesUseCase(this.repository);
+
+  Future<List<Promise>> call() async {
+    return await repository.getPromises();
+  }
+}

--- a/lib/features/promises/domain/usecase/get_promises_usecase.dart
+++ b/lib/features/promises/domain/usecase/get_promises_usecase.dart
@@ -6,7 +6,11 @@ class GetPromisesUseCase {
 
   GetPromisesUseCase(this.repository);
 
-  Future<List<Promise>> call() async {
-    return await repository.getPromises();
+  Future<List<Promise>> getUpcomingPromises(DateTime startDate) {
+    return repository.getUpcomingPromises(startDate);
+  }
+
+  Future<List<Promise>> getPastPromises(DateTime endDate) {
+    return repository.getPastPromises(endDate);
   }
 }

--- a/lib/features/promises/presentation/viewmodels/promises_view_model.dart
+++ b/lib/features/promises/presentation/viewmodels/promises_view_model.dart
@@ -8,17 +8,18 @@ class PromisesViewModel extends StateNotifier<AsyncValue<List<Promise>>> {
   final GetPromisesUseCase _getPromisesUseCase;
 
   PromisesViewModel(this._getPromisesUseCase)
-      : super(const AsyncValue.loading()) {
-    fetchPromises();
+      : super(const AsyncValue.loading());
+
+  Future<List<Promise>> fetchUpcomingPromises(DateTime startDate) async {
+    final promises = await _getPromisesUseCase.getUpcomingPromises(startDate);
+    state = AsyncValue.data(promises);
+    return promises;
   }
 
-  Future<void> fetchPromises() async {
-    try {
-      final promises = await _getPromisesUseCase();
-      state = AsyncValue.data(promises);
-    } catch (e, st) {
-      state = AsyncValue.error(e, st);
-    }
+  Future<List<Promise>> fetchPastPromises(DateTime endDate) async {
+    final promises = await _getPromisesUseCase.getPastPromises(endDate);
+    state = AsyncValue.data(promises);
+    return promises;
   }
 }
 

--- a/lib/features/promises/presentation/viewmodels/promises_view_model.dart
+++ b/lib/features/promises/presentation/viewmodels/promises_view_model.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/core/dio/dio_provider.dart';
+import 'package:pravo_client/features/promises/data/repository/promise_repository.dart';
+import 'package:pravo_client/features/promises/domain/entity/promise.dart';
+import 'package:pravo_client/features/promises/domain/usecase/get_promises_usecase.dart';
+
+class PromisesViewModel extends StateNotifier<AsyncValue<List<Promise>>> {
+  final GetPromisesUseCase _getPromisesUseCase;
+
+  PromisesViewModel(this._getPromisesUseCase)
+      : super(const AsyncValue.loading()) {
+    fetchPromises();
+  }
+
+  Future<void> fetchPromises() async {
+    try {
+      final promises = await _getPromisesUseCase();
+      state = AsyncValue.data(promises);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+}
+
+final promisesViewModelProvider =
+    StateNotifierProvider<PromisesViewModel, AsyncValue<List<Promise>>>(
+  (ref) => PromisesViewModel(
+    GetPromisesUseCase(PromisesRepository(ref.read(dioProvider))),
+  ),
+);

--- a/lib/features/promises/presentation/widgets/promise_list_widget.dart
+++ b/lib/features/promises/presentation/widgets/promise_list_widget.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/promise_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/vertical_gap_widget.dart';
+import 'package:pravo_client/features/promises/domain/entity/promise.dart';
 
 class PromiseListWidget extends StatelessWidget {
+  final List<Promise> promises;
   const PromiseListWidget({
     super.key,
+    required this.promises,
   });
 
   @override
@@ -14,10 +17,16 @@ class PromiseListWidget extends StatelessWidget {
       padding: kScreenPadding,
       child: ListView.separated(
         key: super.key,
-        itemCount: 5,
+        itemCount: promises.length,
         itemBuilder: (context, index) {
-          return const PromiseWidget(
-            promiseId: 1,
+          final promise = promises[index];
+          return PromiseWidget(
+            promiseId: promise.id,
+            promiseName: promise.name,
+            promiseDate: promise.promiseDate,
+            location: promise.location,
+            organizerName: promise.organizerName,
+            organizerProfileImageUrl: promise.organizerProfileImageUrl,
           );
         },
         separatorBuilder: (BuildContext context, int index) {


### PR DESCRIPTION
## 📝 개요
약속 목록 조회 API 연동 입니다! 
아직 서버쪽의 인증 API가 완료되지 않아,, 블락된 부분이 있어서 임시 데이터로 처리했습니다.
또한 도메인 레이어를 사용하는 쪽으로 적용해보았는데, 확실히 도메인 레이어를 껴서 Response에 직접 접근하지 않는 것이 더 코드 가독성도 좋은 것 같고 확장성도 있어보이는 것 같기도 하네요!!

## 🪐 작업 내용

<!-- 작업한 내용을 적어주세요. -->
- [] 탭 접근 시 GET /api/promises?startedAt=2024-10-11 API 호출
- [] 기존 PromiseWidget에서 일단 nullable 프로퍼티로 약속 데이터 받아서 보여줄 수 있도록 수정

## 🛰️ 이슈 번호
#38

## 📚 참고 자료
<img width="347" alt="image" src="https://github.com/user-attachments/assets/9f2d8da2-a378-44f2-b38b-6d3125f0f410">
<img width="347" alt="image" src="https://github.com/user-attachments/assets/6022127d-06ee-4022-9317-50ec7e05a0b9">

연동 대상 스웨거
https://www.pravo.p-e.kr/swagger-ui/index.html#/Promise/getPromisesByMember
응답 스펙에서 organizerName, organizerProfileImageUrl이 노션에는 존재하지만 스웨거 스키마에는 없어서 추가해달라고 요청할 계획입니다 !!
