### PR TITLE
fix: 미인증 시 리디렉션 로직 개선

### DIFF
--- a/lib/features/auth/presentation/viewmodels/auth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/auth_provider.dart
@@ -16,6 +16,11 @@ class AuthNotifier extends ChangeNotifier {
   AuthNotifier({required this.ref})
       : authRepository = ref.read(authRepositoryProvider);
 
+  Future<bool> isTokenValid() async {
+    final token = await _secureStorage.read(key: 'access_token');
+    return token != null;
+  }
+
   Future<void> login(
     String oauthToken,
     Platform oauthPlatform,

--- a/lib/features/auth/presentation/viewmodels/oauth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/oauth_provider.dart
@@ -9,45 +9,18 @@ final oauthProvider =
 class OAuthNotifier extends ChangeNotifier {
   final Ref ref;
   final _secureStorage = const FlutterSecureStorage();
-  bool _isCredentialsLoaded = false;
-  String? _token;
   Platform? _platform;
 
-  OAuthNotifier({required this.ref}) {
-    _loadCredentialsFromStorage(); // 초기화 시 토큰 확인
-  }
+  OAuthNotifier({required this.ref});
 
   Platform? getPlatform() {
     return _platform;
-  }
-
-  /// 저장소에 저장된 정보 확인
-  Future<void> _loadCredentialsFromStorage() async {
-    _token = await _secureStorage.read(key: 'oauth_token');
-
-    String? platform = await _secureStorage.read(key: 'oauth_platform');
-    if (platform == Platform.apple.name) {
-      _platform = Platform.apple;
-    } else if (platform == Platform.kakao.name) {
-      _platform = Platform.kakao;
-    }
-
-    _isCredentialsLoaded = true;
-    notifyListeners();
-  }
-
-  Future<bool> isTokenValid() async {
-    if (!_isCredentialsLoaded) {
-      await _loadCredentialsFromStorage();
-    }
-    return _token != null;
   }
 
   /// 로그인
   Future<void> login(String newToken, Platform newPlatform) async {
     await _secureStorage.write(key: 'oauth_token', value: newToken);
     await _secureStorage.write(key: 'oauth_platform', value: newPlatform.name);
-    _token = newToken;
     _platform = newPlatform;
     notifyListeners();
   }
@@ -56,7 +29,6 @@ class OAuthNotifier extends ChangeNotifier {
   Future<void> logout() async {
     await _secureStorage.delete(key: 'oauth_token');
     await _secureStorage.delete(key: 'oauth_platform');
-    _token = null;
     _platform = null;
     notifyListeners();
   }

--- a/lib/features/auth/presentation/viewmodels/router_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/router_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pravo_client/features/auth/presentation/screens/login_screen.dart';
-import 'package:pravo_client/features/auth/presentation/viewmodels/oauth_provider.dart';
+import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/home/presentation/screens/home_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_complete_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_screen.dart';
@@ -16,7 +16,7 @@ import 'package:pravo_client/features/setting/presentation/screens/setting_scree
 import 'package:pravo_client/features/store/presentation/screens/store_screen.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
-  final authNotifier = ref.read(oauthProvider);
+  final authNotifier = ref.read(authProvider);
 
   final routes = [
     GoRoute(
@@ -90,7 +90,7 @@ final routerProvider = Provider<GoRouter>((ref) {
 
   // 로그인 상태에 따른 리디렉션 로직
   Future<String?> redirectLogic(
-    OAuthNotifier authNotifier,
+    AuthNotifier authNotifier,
     GoRouterState state,
   ) async {
     const loginPath = '/login';

--- a/lib/features/core/dio/dio_provider.dart
+++ b/lib/features/core/dio/dio_provider.dart
@@ -1,8 +1,13 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'dart:developer';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
+import 'package:pravo_client/features/auth/presentation/viewmodels/oauth_provider.dart';
+import 'package:pravo_client/features/auth/presentation/viewmodels/router_provider.dart';
 import 'package:pravo_client/features/core/data/models/api_response_model.dart';
 
 final dioProvider = Provider<Dio>((ref) {
@@ -61,6 +66,11 @@ class CustomInterceptor extends Interceptor {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode == HttpStatus.unauthorized) {
+      ref.read(authProvider).logout();
+      ref.read(oauthProvider).logout();
+      ref.read(routerProvider).go('/login');
+    }
     log('${err.message} - ${err.response?.data}');
     return handler.reject(err);
   }


### PR DESCRIPTION
## 📝 개요
미인증 시 리디렉션 로직 개선 

## 🪐 작업 내용
- [ ] oauth_token 이 아닌 auth_token이 존재할 때, 로그인 페이지 -> 홈으로 리디렉션하도록 수정
- [ ] API 요청 이후 401 응답이 발생하면, 로그인 페이지로 리디렉션

## 🛰️ 이슈 번호
https://github.com/team-pravo/pravo-client/issues/35

## 📚 참고 자료
