### PR TITLE
feat: 인증된 Member 조회 API 연동

### DIFF
--- a/lib/features/auth/data/models/token_response_model.dart
+++ b/lib/features/auth/data/models/token_response_model.dart
@@ -1,13 +1,16 @@
 class LoginResponseModel {
   TokenResponseModel jwtTokens;
+  int memberId;
 
   LoginResponseModel({
     required this.jwtTokens,
+    required this.memberId,
   });
 
   factory LoginResponseModel.fromJson(Map<String, dynamic> json) {
     return LoginResponseModel(
       jwtTokens: TokenResponseModel.fromJson(json['jwtTokens']),
+      memberId: json['memberId'],
     );
   }
 }

--- a/lib/features/auth/presentation/viewmodels/auth_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/auth_provider.dart
@@ -28,12 +28,15 @@ class AuthNotifier extends ChangeNotifier {
     LoginResponseModel response =
         await authRepository.login(oauthToken, oauthPlatform);
     final accessToken = response.jwtTokens.accessToken;
+    final memberId = response.memberId;
     await _secureStorage.write(key: 'access_token', value: accessToken);
+    await _secureStorage.write(key: 'member_id', value: memberId.toString());
     notifyListeners();
   }
 
   Future<void> logout() async {
     await _secureStorage.delete(key: 'access_token');
+    await _secureStorage.delete(key: 'member_id');
     notifyListeners();
   }
 }

--- a/lib/features/auth/presentation/viewmodels/router_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/router_provider.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:pravo_client/features/auth/presentation/screens/login_screen.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/home/presentation/screens/home_screen.dart';
+import 'package:pravo_client/features/member/domain/entities/member.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_complete_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/new_details_screen.dart';
@@ -84,7 +85,10 @@ final routerProvider = Provider<GoRouter>((ref) {
     ),
     GoRoute(
       path: '/profile/edit',
-      builder: (_, __) => const ProfileEditScreen(),
+      builder: (context, state) {
+        final member = state.extra as Member;
+        return ProfileEditScreen(member: member);
+      },
     ),
   ];
 

--- a/lib/features/member/data/models/member_model.dart
+++ b/lib/features/member/data/models/member_model.dart
@@ -1,0 +1,23 @@
+import 'package:pravo_client/features/member/domain/entities/member.dart';
+
+class MemberModel {
+  final String name;
+  final String? profileImageUrl;
+
+  MemberModel({required this.name, this.profileImageUrl});
+
+  factory MemberModel.fromJson(Map<String, dynamic> json) {
+    return MemberModel(
+      name: json['name'],
+      profileImageUrl: json['profileImageUrl'],
+    );
+  }
+
+  Member toEntity(int memberId) {
+    return Member(
+      id: memberId,
+      name: name,
+      profileImageUrl: profileImageUrl,
+    );
+  }
+}

--- a/lib/features/member/data/repositories/member_repository_impl.dart
+++ b/lib/features/member/data/repositories/member_repository_impl.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/core/dio/dio_provider.dart';
+import 'package:pravo_client/features/member/data/models/member_model.dart';
+import 'package:pravo_client/features/member/domain/entities/member.dart';
+import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
+
+final memberRepositoryProvider = Provider<MemberRepository>((ref) {
+  return MemberRepositoryImpl(ref.read(dioProvider));
+});
+
+class MemberRepositoryImpl implements MemberRepository {
+  final Dio dio;
+
+  MemberRepositoryImpl(this.dio);
+
+  @override
+  Future<Member> getMember(int memberId) async {
+    final response = await dio.get('/api/member/$memberId');
+    final memberDto = MemberModel.fromJson(response.data);
+    return memberDto.toEntity(memberId);
+  }
+}

--- a/lib/features/member/domain/entities/member.dart
+++ b/lib/features/member/domain/entities/member.dart
@@ -1,0 +1,7 @@
+class Member {
+  final int id;
+  final String name;
+  final String? profileImageUrl;
+
+  Member({required this.id, required this.name, this.profileImageUrl});
+}

--- a/lib/features/member/domain/repositories/member_repository.dart
+++ b/lib/features/member/domain/repositories/member_repository.dart
@@ -1,0 +1,5 @@
+import 'package:pravo_client/features/member/domain/entities/member.dart';
+
+abstract class MemberRepository {
+  Future<Member> getMember(int id);
+}

--- a/lib/features/member/domain/usecases/get_member_usecase.dart
+++ b/lib/features/member/domain/usecases/get_member_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:pravo_client/features/member/domain/entities/member.dart';
+import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
+
+class GetMemberUseCase {
+  final MemberRepository repository;
+
+  GetMemberUseCase(this.repository);
+
+  Future<Member> getMember(int id) {
+    return repository.getMember(id);
+  }
+}

--- a/lib/features/setting/presentation/screens/profile_edit_screen.dart
+++ b/lib/features/setting/presentation/screens/profile_edit_screen.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
+import 'package:pravo_client/features/member/domain/entities/member.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/nickname_edit_widget.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/profile_image_edit_widget.dart';
 
 class ProfileEditScreen extends StatelessWidget {
-  const ProfileEditScreen({super.key});
+  final Member member;
+  const ProfileEditScreen({super.key, required this.member});
 
   @override
   Widget build(BuildContext context) {
@@ -22,16 +24,18 @@ class ProfileEditScreen extends StatelessWidget {
           Navigator.pop(context);
         },
       ),
-      body: const Padding(
+      body: Padding(
         padding: kScreenPadding,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ProfileImageEditWidget(),
-            SizedBox(
+            ProfileImageEditWidget(
+              profileImageUrl: member.profileImageUrl,
+            ),
+            const SizedBox(
               height: 50,
             ),
-            NicknameEditWidget(),
+            NicknameEditWidget(name: member.name),
           ],
         ),
       ),

--- a/lib/features/setting/presentation/screens/setting_screen.dart
+++ b/lib/features/setting/presentation/screens/setting_screen.dart
@@ -1,16 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth1_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/navigation_bar_widget.dart';
+import 'package:pravo_client/features/setting/presentation/viewmodels/member_view_model.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/profile_preview_widget.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/text_buttons_widget.dart';
 
-class SettingScreen extends StatelessWidget {
+class SettingScreen extends ConsumerStatefulWidget {
   const SettingScreen({super.key});
 
   @override
+  ConsumerState<SettingScreen> createState() => _SettingScreenState();
+}
+
+class _SettingScreenState extends ConsumerState<SettingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(memberViewModelProvider.notifier).getMember();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final memberState = ref.watch(memberViewModelProvider);
+
     return Scaffold(
       appBar: Depth1AppBarWidget(
         title: '설정',
@@ -21,12 +38,20 @@ class SettingScreen extends StatelessWidget {
         child: SingleChildScrollView(
           child: Container(
             padding: kScreenPadding,
-            child: const Column(
+            child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                ProfilePreviewWidget(),
-                SizedBox(height: 50),
-                TextButtonsWidget(),
+                memberState.when(
+                  data: (member) => ProfilePreviewWidget(
+                    name: member.name,
+                    profileImageUrl: member.profileImageUrl,
+                  ),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (err, stack) => Center(child: Text('Error: $err')),
+                ),
+                const SizedBox(height: 50),
+                const TextButtonsWidget(),
               ],
             ),
           ),

--- a/lib/features/setting/presentation/screens/setting_screen.dart
+++ b/lib/features/setting/presentation/screens/setting_screen.dart
@@ -43,8 +43,7 @@ class _SettingScreenState extends ConsumerState<SettingScreen> {
               children: [
                 memberState.when(
                   data: (member) => ProfilePreviewWidget(
-                    name: member.name,
-                    profileImageUrl: member.profileImageUrl,
+                    member: member,
                   ),
                   loading: () =>
                       const Center(child: CircularProgressIndicator()),

--- a/lib/features/setting/presentation/viewmodels/member_view_model.dart
+++ b/lib/features/setting/presentation/viewmodels/member_view_model.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pravo_client/features/member/data/repositories/member_repository_impl.dart';
+import 'package:pravo_client/features/member/domain/entities/member.dart';
+import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
+
+final memberViewModelProvider =
+    StateNotifierProvider<MemberViewModel, AsyncValue<Member>>((ref) {
+  return MemberViewModel(memberRepository: ref.watch(memberRepositoryProvider));
+});
+
+class MemberViewModel extends StateNotifier<AsyncValue<Member>> {
+  final MemberRepository memberRepository;
+  final _secureStorage = const FlutterSecureStorage();
+
+  MemberViewModel({
+    required this.memberRepository,
+  }) : super(const AsyncValue.loading());
+
+  Future<void> getMember() async {
+    final memberId = await _secureStorage.read(key: 'member_id');
+    if (memberId == null) {
+      state = AsyncValue.error(
+        'Member ID not found in secure storage',
+        StackTrace.current,
+      );
+      return;
+    }
+    final member = await memberRepository.getMember(int.parse(memberId));
+    state = AsyncValue.data(member);
+  }
+}

--- a/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
+++ b/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
@@ -3,8 +3,10 @@ import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/text_field_error_message_widget.dart';
 
 class NicknameEditWidget extends StatelessWidget {
+  final String name;
   const NicknameEditWidget({
     super.key,
+    required this.name,
   });
 
   @override
@@ -12,9 +14,9 @@ class NicknameEditWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          '닉네임',
-          style: TextStyle(
+        Text(
+          name,
+          style: const TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w500,
           ),
@@ -24,7 +26,7 @@ class NicknameEditWidget extends StatelessWidget {
         ),
         TextField(
           decoration: kInputFieldDecoration.copyWith(
-            hintText: '닉네임을 입력하세요',
+            hintText: name,
           ),
           style: const TextStyle(
             fontSize: kInputTextFontSize,
@@ -34,6 +36,7 @@ class NicknameEditWidget extends StatelessWidget {
           height: 8,
         ),
         const TextFieldErrorMessageWidget(
+          // FIXME: 프로필 수정 API가 개발 완료되면, 프로필 수정 API의 호출 결과에 따라 노출하도록 수정할 것
           title: '이미 사용 중인 닉네임이에요. 다른 닉네임을 골라볼까요?',
         ),
       ],

--- a/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
+++ b/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
@@ -14,9 +14,9 @@ class NicknameEditWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          name,
-          style: const TextStyle(
+        const Text(
+          '닉네임',
+          style: TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w500,
           ),

--- a/lib/features/setting/presentation/widgets/profile_image_edit_widget.dart
+++ b/lib/features/setting/presentation/widgets/profile_image_edit_widget.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:pravo_client/assets/constants.dart';
 
 class ProfileImageEditWidget extends StatelessWidget {
+  final String? profileImageUrl;
   const ProfileImageEditWidget({
     super.key,
+    this.profileImageUrl,
   });
 
   @override
@@ -14,12 +16,16 @@ class ProfileImageEditWidget extends StatelessWidget {
           CircleAvatar(
             backgroundColor: kAvatarBackgroundColor,
             radius: 42,
-            child: Padding(
-              padding: const EdgeInsets.all(7.0),
-              child: Image.asset(
-                'assets/images/avocado.png',
-              ),
-            ),
+            backgroundImage:
+                profileImageUrl != null ? NetworkImage(profileImageUrl!) : null,
+            child: profileImageUrl == null
+                ? Padding(
+                    padding: const EdgeInsets.all(7.0),
+                    child: Image.asset(
+                      'assets/images/avocado.png',
+                    ),
+                  )
+                : null,
           ),
           Positioned(
             bottom: 2,

--- a/lib/features/setting/presentation/widgets/profile_preview_widget.dart
+++ b/lib/features/setting/presentation/widgets/profile_preview_widget.dart
@@ -2,20 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
+import 'package:pravo_client/features/member/domain/entities/member.dart';
 
 class ProfilePreviewWidget extends StatelessWidget {
-  final String name;
-  final String? profileImageUrl;
+  final Member member;
   const ProfilePreviewWidget({
     super.key,
-    required this.name,
-    this.profileImageUrl,
+    required this.member,
   });
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => context.push('/profile/edit'),
+      onTap: () => context.push('/profile/edit', extra: member),
       child: Container(
         padding: kWidgetPadding,
         decoration: BoxDecoration(
@@ -29,10 +28,10 @@ class ProfilePreviewWidget extends StatelessWidget {
               children: [
                 CircleAvatar(
                   backgroundColor: kAvatarBackgroundColor,
-                  backgroundImage: profileImageUrl != null
-                      ? NetworkImage(profileImageUrl!)
+                  backgroundImage: member.profileImageUrl != null
+                      ? NetworkImage(member.profileImageUrl!)
                       : null,
-                  child: profileImageUrl == null
+                  child: member.profileImageUrl == null
                       ? Padding(
                           padding: const EdgeInsets.all(6),
                           child: Image.asset(
@@ -43,7 +42,7 @@ class ProfilePreviewWidget extends StatelessWidget {
                 ),
                 const SizedBox(width: 12),
                 Text(
-                  name,
+                  member.name,
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,

--- a/lib/features/setting/presentation/widgets/profile_preview_widget.dart
+++ b/lib/features/setting/presentation/widgets/profile_preview_widget.dart
@@ -4,7 +4,13 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 
 class ProfilePreviewWidget extends StatelessWidget {
-  const ProfilePreviewWidget({super.key});
+  final String name;
+  final String? profileImageUrl;
+  const ProfilePreviewWidget({
+    super.key,
+    required this.name,
+    this.profileImageUrl,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -23,18 +29,22 @@ class ProfilePreviewWidget extends StatelessWidget {
               children: [
                 CircleAvatar(
                   backgroundColor: kAvatarBackgroundColor,
-                  radius: 24,
-                  child: Padding(
-                    padding: const EdgeInsets.all(7.0),
-                    child: Image.asset(
-                      'assets/images/avocado.png',
-                    ),
-                  ),
+                  backgroundImage: profileImageUrl != null
+                      ? NetworkImage(profileImageUrl!)
+                      : null,
+                  child: profileImageUrl == null
+                      ? Padding(
+                          padding: const EdgeInsets.all(6),
+                          child: Image.asset(
+                            'assets/images/avocado.png',
+                          ),
+                        )
+                      : null,
                 ),
                 const SizedBox(width: 12),
-                const Text(
-                  'Mr. Avocado',
-                  style: TextStyle(
+                Text(
+                  name,
+                  style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
                   ),


### PR DESCRIPTION
## 📝 개요
Member 조회 API 연동

## 🪐 작업 내용
- [] 최초 로그인 시, SecureStorage에 `member_id` 저장
- [] 설정 페이지 진입 시, GET /member/{memberId} API 호출
- [] 프로필 프리뷰 & 수정 위젯에서 받아온 멤버의 사진과 닉네임 노출

## 🛰️ 이슈 번호
#56


## 📚 참고 자료
![Simulator Screenshot - iPhone 15 - 2024-11-20 at 20 11 19](https://github.com/user-attachments/assets/9fd02ef4-b58b-4de9-8228-c1ad5a9f2f6c)
![Simulator Screenshot - iPhone 15 - 2024-11-20 at 20 05 29](https://github.com/user-attachments/assets/a8dcfff1-652e-4310-a67d-3a5d322368b3)

### 수정 후
![image](https://github.com/user-attachments/assets/aaf8bc98-d43d-4467-a25b-b4384c318760)

