### PR TITLE
feat: 에러 스크린 구현

### DIFF
--- a/lib/features/auth/presentation/viewmodels/router_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/router_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pravo_client/features/auth/presentation/screens/login_screen.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
+import 'package:pravo_client/features/error/presentation/screens/error_screen.dart';
 import 'package:pravo_client/features/home/presentation/screens/home_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_complete_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_screen.dart';
@@ -86,6 +87,17 @@ final routerProvider = Provider<GoRouter>((ref) {
       path: '/profile/edit',
       builder: (_, __) => const ProfileEditScreen(),
     ),
+    GoRoute(
+      path: '/error',
+      builder: (_, state) {
+        final data = state.extra! as Map<String, dynamic>;
+        return ErrorScreen(
+          appBarTitle: data['appBarTitle'],
+          errorTitle: data['errorTitle'],
+          errorMessage: data['errorMessage'],
+        );
+      },
+    ),
   ];
 
   // 로그인 상태에 따른 리디렉션 로직
@@ -106,9 +118,14 @@ final routerProvider = Provider<GoRouter>((ref) {
 
   return GoRouter(
     routes: routes,
-    redirect: (_, state) =>
-        redirectLogic(authNotifier, state), // navigate될 때마다 호출
-    refreshListenable:
-        authNotifier, // authProvider 상태를 listen하여 상태가 변하면 redirect 실행
+    redirect: (_, state) => redirectLogic(authNotifier, state),
+    refreshListenable: authNotifier,
+    errorBuilder: (context, state) {
+      return const ErrorScreen(
+        appBarTitle: '페이지 오류',
+        errorTitle: '찾을 수 없는 페이지',
+        errorMessage: '요청하신 페이지가 존재하지 않습니다.',
+      );
+    },
   );
 });

--- a/lib/features/error/presentation/screens/error_screen.dart
+++ b/lib/features/error/presentation/screens/error_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:pravo_client/assets/constants.dart';
+import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
+import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
+
+class ErrorScreen extends StatelessWidget {
+  final String appBarTitle;
+  final String errorTitle;
+  final String errorMessage;
+
+  const ErrorScreen({
+    super.key,
+    required this.appBarTitle,
+    required this.errorTitle,
+    required this.errorMessage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: Depth2AppBarWidget(title: appBarTitle),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: kScreenPadding,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const SizedBox(
+                      height: 70,
+                    ),
+                    PhosphorIcon(
+                      PhosphorIcons.warningCircle(
+                        PhosphorIconsStyle.regular,
+                      ),
+                      size: 70,
+                    ),
+                    const SizedBox(
+                      height: 20,
+                    ),
+                    Text(
+                      errorTitle,
+                      style: const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    Text(
+                      errorMessage,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: kBodyTextColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            PrimaryButtonWidget(
+              buttonText: '홈으로 돌아가기',
+              onTap: () => context.go('/'),
+              hasHorizontalMargin: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth1_app_bar_widget.dart';
@@ -17,7 +18,9 @@ class HomeScreen extends ConsumerWidget {
       appBar: Depth1AppBarWidget(
         title: '홈',
         actionIcon: PhosphorIcons.bell(),
-        actionOnPressed: () {},
+        actionOnPressed: () {
+          context.push('/hello'); //FIXME: 테스트를 위한 코드이므로 추후 삭제 예정
+        },
       ),
       body: const SingleChildScrollView(
         child: Padding(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -295,7 +295,7 @@ packages:
     source: hosted
     version: "2.3.7"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"


### PR DESCRIPTION
<!--
제목 앞에 아래 라벨을 추가해주세요.
 - feat: 기능 추가
 - fix: 버그 수정
 - refactor: 코드 리팩토링
 - chore: 패키지 매니저 업데이트, 빌드 관련
 - test: 테스트 코드 작성 및 수정
 - docs: 문서 업데이트
-->

## 📝 개요

<!-- 어떤 변경사항이 있는지 설명해주세요. -->

에러 스크린 구현

## 🪐 작업 내용

<!-- 작업한 내용을 적어주세요. -->

- [x] 에러 스크린 구현
- [x] 존재하지 않는 URL 과 '/error' 에 에러 스크린 연결


## 🛰️ 이슈 번호

<!-- 관련된 이슈 번호를 적어주세요. -->

#53 

## 📚 참고 자료

<!-- (선택) 참고할만한 자료 및 파일이 있다면 첨부해주세요. -->

- 스크린 테스트를 위해서 홈 화면의 알림 아이콘 클릭 시 에러 스크린으로 연결되도록 구현했습니다.

<img width="506" alt="image" src="https://github.com/user-attachments/assets/0191998d-d438-4ca5-ae67-04e6264b311b">

