### PR TITLE
feat: 약속 삭제/취소 API 연동

### DIFF
--- a/lib/features/promise/data/repositories/promise_repository_impl.dart
+++ b/lib/features/promise/data/repositories/promise_repository_impl.dart
@@ -48,4 +48,11 @@ class PromiseRepositoryImpl implements PromiseRepository {
           .toList(),
     );
   }
+
+  @override
+  Future<void> deletePromise(int id) async {
+    await dio.delete(
+      '/api/promise/$id',
+    );
+  }
 }

--- a/lib/features/promise/data/repositories/promise_repository_impl.dart
+++ b/lib/features/promise/data/repositories/promise_repository_impl.dart
@@ -55,4 +55,11 @@ class PromiseRepositoryImpl implements PromiseRepository {
       '/api/promise/$id',
     );
   }
+
+  @override
+  Future<void> cancelPromise(int id) async {
+    await dio.delete(
+      '/api/promise/$id/cancel',
+    );
+  }
 }

--- a/lib/features/promise/domain/entities/button_status.dart
+++ b/lib/features/promise/domain/entities/button_status.dart
@@ -1,0 +1,22 @@
+enum ButtonStatus {
+  copyInvitationLink('초대 링크 복사'),
+  goToAttendanceConfirmation('참석 확인하러 가기'),
+  hidden(''); // 버튼 숨김 상태
+
+  final String text;
+
+  const ButtonStatus(this.text);
+
+  static ButtonStatus getButtonStatus(bool isOrganizer, DateTime scheduledAt) {
+    final currentTime = DateTime.now();
+    final timeDifferenceInMinutes =
+        scheduledAt.difference(currentTime).inMinutes;
+
+    if (isOrganizer) {
+      return timeDifferenceInMinutes <= 60
+          ? ButtonStatus.goToAttendanceConfirmation
+          : ButtonStatus.copyInvitationLink;
+    }
+    return ButtonStatus.hidden;
+  }
+}

--- a/lib/features/promise/domain/repositories/promise_repository.dart
+++ b/lib/features/promise/domain/repositories/promise_repository.dart
@@ -2,4 +2,5 @@ import 'package:pravo_client/features/promise/domain/entities/promise.dart';
 
 abstract class PromiseRepository {
   Future<Promise> getPromise(int id);
+  Future<void> deletePromise(int id);
 }

--- a/lib/features/promise/domain/repositories/promise_repository.dart
+++ b/lib/features/promise/domain/repositories/promise_repository.dart
@@ -3,4 +3,5 @@ import 'package:pravo_client/features/promise/domain/entities/promise.dart';
 abstract class PromiseRepository {
   Future<Promise> getPromise(int id);
   Future<void> deletePromise(int id);
+  Future<void> cancelPromise(int id);
 }

--- a/lib/features/promise/domain/usecases/get_promise_usecase.dart
+++ b/lib/features/promise/domain/usecases/get_promise_usecase.dart
@@ -13,4 +13,8 @@ class GetPromiseUseCase {
   Future<void> deletePromise(int id) {
     return repository.deletePromise(id);
   }
+
+  Future<void> cancelPromise(int id) {
+    return repository.cancelPromise(id);
+  }
 }

--- a/lib/features/promise/domain/usecases/get_promise_usecase.dart
+++ b/lib/features/promise/domain/usecases/get_promise_usecase.dart
@@ -9,4 +9,8 @@ class GetPromiseUseCase {
   Future<Promise> getPromise(int id) {
     return repository.getPromise(id);
   }
+
+  Future<void> deletePromise(int id) {
+    return repository.deletePromise(id);
+  }
 }

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -7,7 +7,6 @@ import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/alert_dialog_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
-import 'package:pravo_client/features/promise/domain/entities/promise.dart';
 import 'package:pravo_client/features/promise/presentation/viewmodels/promise_view_model.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/deposit_widget.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/participants_and_status_widget.dart';
@@ -20,12 +19,7 @@ enum ButtonState {
   hidden, // 버튼 숨김 상태
 }
 
-final promiseProvider =
-    FutureProvider.autoDispose.family<Promise, int>((ref, promiseId) {
-  return ref.read(promiseViewModelProvider.notifier).getPromise(promiseId);
-});
-
-class PromiseDetailScreen extends ConsumerWidget {
+class PromiseDetailScreen extends ConsumerStatefulWidget {
   final int promiseId;
   final bool isAttendanceConfirmed;
 
@@ -35,115 +29,144 @@ class PromiseDetailScreen extends ConsumerWidget {
     this.isAttendanceConfirmed = false,
   });
 
-  ButtonState getButtonState() {
-    return ButtonState.goToAttendanceConfirmation;
+  ButtonState getButtonState(bool isOrganizer, DateTime scheduledAt) {
+    final currentTime = DateTime.now();
+    final timeDifferenceInMinutes =
+        scheduledAt.difference(currentTime).inMinutes;
+
+    if (isOrganizer) {
+      return timeDifferenceInMinutes <= 60
+          ? ButtonState.goToAttendanceConfirmation
+          : ButtonState.copyInvitationLink;
+    }
+    return ButtonState.hidden;
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final buttonState = getButtonState();
+  ConsumerState<PromiseDetailScreen> createState() =>
+      _PromiseDetailScreenState();
+}
 
-    return Scaffold(
-      appBar: Depth2AppBarWidget(
-        title: '약속 상세',
-        leadingIcon: PhosphorIcons.caretLeft(),
-        leadingOnPressed: () => context.pop(),
-        actionIcon: PhosphorIcons.trash(),
-        actionOnPressed: () => {
-          showDialog(
-            context: context,
-            builder: (context) => AlertDialogWidget(
-              title: '약속을 삭제할까요?',
-              content: '이미 만들어진 약속을 삭제하면\n참여한 사람들이 당황할 수 있어요.',
-              actionOnPressed: () async {
-                await ref
-                    .read(promiseViewModelProvider.notifier)
-                    .deletePromise(promiseId);
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('약속이 삭제되었습니다.')),
-                  );
-                  context.go('/');
-                }
-              },
-              actionTitle: '삭제',
-            ),
-          ),
-        },
-      ),
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Padding(
-                padding: kScreenPadding,
-                child: SingleChildScrollView(
-                  child: Consumer(
-                    builder: (context, ref, child) {
-                      final promiseAsync =
-                          ref.watch(promiseProvider(promiseId));
-                      return promiseAsync.when(
-                        data: (promise) => Column(
-                          children: [
-                            PromiseOverviewWidget(
-                              name: promise.name,
-                              location: promise.location,
-                              promiseDate: promise.promiseDate,
-                              organizer: promise.participants.firstWhere(
-                                (participant) =>
-                                    participant.role == 'ORGANIZER',
-                                orElse: () => throw Exception(
-                                  'No participant with role ORGANIZER found',
-                                ),
-                              ),
-                            ),
-                            ParticipantsAndStatusWidget(
-                              participants: promise.participants,
-                            ),
-                            DepositWidget(
-                              deposit: promise.deposit,
-                            ),
-                            const PromiseStatusWidget(),
-                          ],
-                        ),
-                        loading: () =>
-                            const Center(child: CircularProgressIndicator()),
-                        error: (error, stack) =>
-                            Center(child: Text('Error: $error')),
+class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(promiseViewModelProvider.notifier).getPromise(widget.promiseId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final promiseState = ref.watch(promiseViewModelProvider);
+
+    return promiseState.when(
+      data: (state) {
+        final promise = state.promise;
+        final isOrganizer = state.isOrganizer;
+        final buttonState =
+            widget.getButtonState(isOrganizer, promise.promiseDate);
+
+        return Scaffold(
+          appBar: Depth2AppBarWidget(
+            title: '약속 상세',
+            leadingIcon: PhosphorIcons.caretLeft(),
+            leadingOnPressed: () => context.pop(),
+            actionIcon: PhosphorIcons.trash(),
+            actionOnPressed: () => {
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialogWidget(
+                  title: '약속을 삭제할까요?',
+                  content: '이미 만들어진 약속을 삭제하면\n참여한 사람들이 당황할 수 있어요.',
+                  actionOnPressed: () async {
+                    await ref
+                        .read(promiseViewModelProvider.notifier)
+                        .deleteOrCancelPromise(
+                          promise.id,
+                          isOrganizer,
+                        );
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('약속이 삭제되었습니다.')),
                       );
-                    },
-                  ),
+                      context.go('/');
+                    }
+                  },
+                  actionTitle: '삭제',
                 ),
               ),
+            },
+          ),
+          body: SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: kScreenPadding,
+                    child: SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          PromiseOverviewWidget(
+                            name: promise.name,
+                            location: promise.location,
+                            promiseDate: promise.promiseDate,
+                            organizer: promise.participants.firstWhere(
+                              (participant) => participant.role == 'ORGANIZER',
+                            ),
+                          ),
+                          ParticipantsAndStatusWidget(
+                            participants: promise.participants,
+                          ),
+                          DepositWidget(
+                            deposit: promise.deposit,
+                          ),
+                          const PromiseStatusWidget(),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                if (buttonState != ButtonState.hidden)
+                  PrimaryButtonWidget(
+                    isEnabled: true,
+                    onTap: () {
+                      if (buttonState == ButtonState.copyInvitationLink) {
+                        Clipboard.setData(const ClipboardData(text: '초대 링크'));
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
+                        );
+                      } else if (buttonState ==
+                          ButtonState.goToAttendanceConfirmation) {
+                        context.push(
+                          '/promise/${widget.promiseId}/confirm-attendance',
+                        );
+                      }
+                    },
+                    buttonColor: kPrimaryColor,
+                    textColor: Colors.white,
+                    buttonText: buttonState == ButtonState.copyInvitationLink
+                        ? '초대 링크 복사'
+                        : '참석 확인하러 가기',
+                    icon: buttonState == ButtonState.copyInvitationLink
+                        ? PhosphorIcons.link(PhosphorIconsStyle.bold)
+                        : null,
+                    iconBeforeText: true,
+                    hasHorizontalMargin: true,
+                  ),
+              ],
             ),
-            if (buttonState != ButtonState.hidden)
-              PrimaryButtonWidget(
-                isEnabled: true,
-                onTap: () {
-                  if (buttonState == ButtonState.copyInvitationLink) {
-                    Clipboard.setData(const ClipboardData(text: '초대 링크'));
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
-                    );
-                  } else if (buttonState ==
-                      ButtonState.goToAttendanceConfirmation) {
-                    context.push('/promise/$promiseId/confirm-attendance');
-                  }
-                },
-                buttonColor: kPrimaryColor,
-                textColor: Colors.white,
-                buttonText: buttonState == ButtonState.copyInvitationLink
-                    ? '초대 링크 복사'
-                    : '참석 확인하러 가기',
-                icon: buttonState == ButtonState.copyInvitationLink
-                    ? PhosphorIcons.link(PhosphorIconsStyle.bold)
-                    : null,
-                iconBeforeText: true,
-                hasHorizontalMargin: true,
-              ),
-          ],
-        ),
+          ),
+        );
+      },
+      loading: () => const Scaffold(
+        appBar: Depth2AppBarWidget(title: '약속 상세'),
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (error, stack) => Scaffold(
+        appBar: const Depth2AppBarWidget(title: '약속 상세'),
+        body: Center(child: Text('Error: $error')),
       ),
     );
   }

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -55,11 +55,16 @@ class PromiseDetailScreen extends ConsumerWidget {
             builder: (context) => AlertDialogWidget(
               title: '약속을 삭제할까요?',
               content: '이미 만들어진 약속을 삭제하면\n참여한 사람들이 당황할 수 있어요.',
-              actionOnPressed: () {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('약속이 삭제되었습니다.')),
-                );
-                Navigator.of(context).pop();
+              actionOnPressed: () async {
+                await ref
+                    .read(promiseViewModelProvider.notifier)
+                    .deletePromise(promiseId);
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('약속이 삭제되었습니다.')),
+                  );
+                  context.go('/');
+                }
               },
               actionTitle: '삭제',
             ),

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -7,17 +7,12 @@ import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/alert_dialog_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
+import 'package:pravo_client/features/promise/domain/entities/button_status.dart';
 import 'package:pravo_client/features/promise/presentation/viewmodels/promise_view_model.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/deposit_widget.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/participants_and_status_widget.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/promise_overview_widget.dart';
 import 'package:pravo_client/features/promise/presentation/widgets/promise_status_widget.dart';
-
-enum ButtonState {
-  copyInvitationLink, // 초대 링크 복사 상태
-  goToAttendanceConfirmation, // 참석 확인하러 가기 상태
-  hidden, // 버튼 숨김 상태
-}
 
 class PromiseDetailScreen extends ConsumerStatefulWidget {
   final int promiseId;
@@ -28,19 +23,6 @@ class PromiseDetailScreen extends ConsumerStatefulWidget {
     required this.promiseId,
     this.isAttendanceConfirmed = false,
   });
-
-  ButtonState getButtonState(bool isOrganizer, DateTime scheduledAt) {
-    final currentTime = DateTime.now();
-    final timeDifferenceInMinutes =
-        scheduledAt.difference(currentTime).inMinutes;
-
-    if (isOrganizer) {
-      return timeDifferenceInMinutes <= 60
-          ? ButtonState.goToAttendanceConfirmation
-          : ButtonState.copyInvitationLink;
-    }
-    return ButtonState.hidden;
-  }
 
   @override
   ConsumerState<PromiseDetailScreen> createState() =>
@@ -64,8 +46,8 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
       data: (state) {
         final promise = state.promise;
         final isOrganizer = state.isOrganizer;
-        final buttonState =
-            widget.getButtonState(isOrganizer, promise.promiseDate);
+        final buttonStatus =
+            ButtonStatus.getButtonStatus(isOrganizer, promise.promiseDate);
 
         return Scaffold(
           appBar: Depth2AppBarWidget(
@@ -128,17 +110,17 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
                     ),
                   ),
                 ),
-                if (buttonState != ButtonState.hidden)
+                if (buttonStatus != ButtonStatus.hidden)
                   PrimaryButtonWidget(
                     isEnabled: true,
                     onTap: () {
-                      if (buttonState == ButtonState.copyInvitationLink) {
+                      if (buttonStatus == ButtonStatus.copyInvitationLink) {
                         Clipboard.setData(const ClipboardData(text: '초대 링크'));
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
                         );
-                      } else if (buttonState ==
-                          ButtonState.goToAttendanceConfirmation) {
+                      } else if (buttonStatus ==
+                          ButtonStatus.goToAttendanceConfirmation) {
                         context.push(
                           '/promise/${widget.promiseId}/confirm-attendance',
                         );
@@ -146,10 +128,8 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
                     },
                     buttonColor: kPrimaryColor,
                     textColor: Colors.white,
-                    buttonText: buttonState == ButtonState.copyInvitationLink
-                        ? '초대 링크 복사'
-                        : '참석 확인하러 가기',
-                    icon: buttonState == ButtonState.copyInvitationLink
+                    buttonText: buttonStatus.text,
+                    icon: buttonStatus == ButtonStatus.copyInvitationLink
                         ? PhosphorIcons.link(PhosphorIconsStyle.bold)
                         : null,
                     iconBeforeText: true,

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -59,8 +59,10 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
               showDialog(
                 context: context,
                 builder: (context) => AlertDialogWidget(
-                  title: '약속을 삭제할까요?',
-                  content: '이미 만들어진 약속을 삭제하면\n참여한 사람들이 당황할 수 있어요.',
+                  title: isOrganizer ? '약속을 삭제할까요?' : '약속을 취소할까요?',
+                  content: isOrganizer
+                      ? '약속을 삭제하면 모두의 예약금이 환급돼요.'
+                      : '약속을 취소하면 예약금이 환급되지 않아요.',
                   actionOnPressed: () async {
                     await ref
                         .read(promiseViewModelProvider.notifier)
@@ -70,7 +72,11 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
                         );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('약속이 삭제되었습니다.')),
+                        SnackBar(
+                          content: Text(
+                            isOrganizer ? '약속이 삭제되었습니다.' : '약속이 취소되었습니다.',
+                          ),
+                        ),
                       );
                       context.go('/');
                     }

--- a/lib/features/promise/presentation/viewmodels/promise_view_model.dart
+++ b/lib/features/promise/presentation/viewmodels/promise_view_model.dart
@@ -3,7 +3,7 @@ import 'package:pravo_client/features/promise/data/repositories/promise_reposito
 import 'package:pravo_client/features/promise/domain/entities/promise.dart';
 import 'package:pravo_client/features/promise/domain/usecases/get_promise_usecase.dart';
 
-class PromiseViewModel extends StateNotifier<AsyncValue<Promise>> {
+class PromiseViewModel extends StateNotifier<AsyncValue<Promise?>> {
   final GetPromiseUseCase _getPromiseUseCase;
 
   PromiseViewModel(this._getPromiseUseCase) : super(const AsyncValue.loading());
@@ -13,10 +13,15 @@ class PromiseViewModel extends StateNotifier<AsyncValue<Promise>> {
     state = AsyncValue.data(promise);
     return promise;
   }
+
+  Future<void> deletePromise(int id) async {
+    await _getPromiseUseCase.deletePromise(id);
+    state = const AsyncValue.data(null);
+  }
 }
 
 final promiseViewModelProvider =
-    StateNotifierProvider<PromiseViewModel, AsyncValue<Promise>>(
+    StateNotifierProvider<PromiseViewModel, AsyncValue<Promise?>>(
   (ref) => PromiseViewModel(
     GetPromiseUseCase(ref.read(promiseRepositoryProvider)),
   ),

--- a/lib/features/promise/presentation/viewmodels/promise_view_model.dart
+++ b/lib/features/promise/presentation/viewmodels/promise_view_model.dart
@@ -41,8 +41,7 @@ class PromiseViewModel extends StateNotifier<AsyncValue<PromiseState>> {
     if (isOrganizer) {
       await _getPromiseUseCase.deletePromise(promiseId);
     } else {
-      // TODO: 취소 API 연동
-      // await _getPromiseUseCase.cancelPromise(promiseId);
+      await _getPromiseUseCase.cancelPromise(promiseId);
     }
   }
 }


### PR DESCRIPTION
## 📝 개요
약속 삭제/취소 API 연동

## 🪐 작업 내용
- [x] 약속 삭제/취소 API 연동
- [x] 모임장 여부에 따라서 삭제 호출할지 취소 호출할지 분기
- [x] 모임장 여부 및 약속까지 남은 시간에 따라서 Button의 Text 분기
- [x] ButtonStatus 외부 파일로 분리하고 리팩터

## 🛰️ 이슈 번호
#42

## 📚 참고 자료
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 19 51](https://github.com/user-attachments/assets/bb0b87fd-777b-4da7-84c4-5e75ef568e11)
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 19 58](https://github.com/user-attachments/assets/400ecd03-7f11-479c-bf1a-961bf55a641e)
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 20 04](https://github.com/user-attachments/assets/f7c69fec-7d88-442e-9b92-90e18ee4c04b)
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 20 09](https://github.com/user-attachments/assets/1a223c2a-e944-4f65-811d-4d5a263aa5e9)
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 20 16](https://github.com/user-attachments/assets/4fda6e38-83a0-4e65-90b8-ca6780beee59)
![Simulator Screenshot - iPhone 15 - 2024-11-22 at 12 22 43](https://github.com/user-attachments/assets/cbf0b906-307a-48e3-9930-ea28f0559abf)
ㄴ 약속 시간이 지났거나, 약속 시간까지 60분 이하로 남았다면 '참석 여부 확인' 버튼 노출
