### PR TITLE
feat: 모임원 약속 참가 및 결제 요청 API 연동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:label="pravo_client"
+        android:label="PRAVO"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">
@@ -49,7 +49,7 @@
 
             <!-- Deep Link -->
             <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Pravo Client</string>
+	<string>PRAVO</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Pravo</string>
+	<string>PRAVO</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -35,6 +35,10 @@
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>CFBundleURLIconFile</key>
+			<string></string>
+			<key>CFBundleURLName</key>
+			<string>pravo.com</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>pravo</string>

--- a/lib/features/auth/presentation/viewmodels/router_provider.dart
+++ b/lib/features/auth/presentation/viewmodels/router_provider.dart
@@ -4,6 +4,8 @@ import 'package:pravo_client/features/auth/presentation/screens/login_screen.dar
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
 import 'package:pravo_client/features/error/presentation/screens/error_screen.dart';
 import 'package:pravo_client/features/home/presentation/screens/home_screen.dart';
+import 'package:pravo_client/features/join/presentation/screens/join_complete_screen.dart';
+import 'package:pravo_client/features/join/presentation/screens/join_deposit_screen.dart';
 import 'package:pravo_client/features/member/domain/entities/member.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_complete_screen.dart';
 import 'package:pravo_client/features/new/presentation/screens/deposit_payment_screen.dart';
@@ -41,7 +43,15 @@ final routerProvider = Provider<GoRouter>((ref) {
       },
       routes: [
         GoRoute(
-          path: 'confirm-attendance',
+          path: 'join/deposit',
+          builder: (_, __) => const JoinDepositScreen(),
+        ),
+        GoRoute(
+          path: 'join/complete',
+          builder: (_, __) => const JoinCompleteScreen(),
+        ),
+        GoRoute(
+          path: 'settlement/attendance',
           builder: (_, state) {
             final promiseId = int.parse(state.pathParameters['promiseId']!);
             return ConfirmAttendanceScreen(promiseId: promiseId);

--- a/lib/features/join/data/repositories/join_repository_impl.dart
+++ b/lib/features/join/data/repositories/join_repository_impl.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/core/dio/dio_provider.dart';
+import 'package:pravo_client/features/join/domain/repositories/join_repository.dart';
+import 'package:pravo_client/features/new/data/models/payment_response_model.dart';
+import 'package:pravo_client/features/new/domain/entities/payment_response.dart';
+
+class JoinRepositoryImpl implements JoinRepository {
+  final Dio dio;
+
+  JoinRepositoryImpl(this.dio);
+
+  @override
+  Future<void> joinPromise(int promiseId) async {
+    await dio.post('/api/promise/$promiseId/join');
+  }
+
+  @override
+  Future<PaymentResponse> requestPayment(int promiseId) async {
+    final response = await dio.post('/api/promise/request/$promiseId');
+    final responseModel = PaymentResponseModel.fromJson(response.data);
+
+    return PaymentResponse(
+      orderId: responseModel.orderId,
+      promiseId: responseModel.promiseId,
+    );
+  }
+}
+
+final joinRepositoryProvider = Provider<JoinRepository>(
+  (ref) => JoinRepositoryImpl(ref.read(dioProvider)),
+);

--- a/lib/features/join/data/repositories/join_repository_impl.dart
+++ b/lib/features/join/data/repositories/join_repository_impl.dart
@@ -17,7 +17,7 @@ class JoinRepositoryImpl implements JoinRepository {
 
   @override
   Future<PaymentResponse> requestPayment(int promiseId) async {
-    final response = await dio.post('/api/promise/request/$promiseId');
+    final response = await dio.post('/api/payment/request/$promiseId');
     final responseModel = PaymentResponseModel.fromJson(response.data);
 
     return PaymentResponse(

--- a/lib/features/join/domain/repositories/join_repository.dart
+++ b/lib/features/join/domain/repositories/join_repository.dart
@@ -1,0 +1,6 @@
+import 'package:pravo_client/features/new/domain/entities/payment_response.dart';
+
+abstract class JoinRepository {
+  Future<void> joinPromise(int promiseId);
+  Future<PaymentResponse> requestPayment(int promiseId);
+}

--- a/lib/features/join/domain/usecases/join_promise_usecase.dart
+++ b/lib/features/join/domain/usecases/join_promise_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:pravo_client/features/join/domain/repositories/join_repository.dart';
+
+class JoinPromiseUseCase {
+  final JoinRepository repository;
+
+  JoinPromiseUseCase(this.repository);
+
+  Future<void> joinPromise(int promiseId) {
+    return repository.joinPromise(promiseId);
+  }
+}

--- a/lib/features/join/domain/usecases/join_promise_usecase.dart
+++ b/lib/features/join/domain/usecases/join_promise_usecase.dart
@@ -5,7 +5,7 @@ class JoinPromiseUseCase {
 
   JoinPromiseUseCase(this.repository);
 
-  Future<void> joinPromise(int promiseId) {
+  Future<void> execute(int promiseId) {
     return repository.joinPromise(promiseId);
   }
 }

--- a/lib/features/join/domain/usecases/request_payment_usecase.dart
+++ b/lib/features/join/domain/usecases/request_payment_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:pravo_client/features/join/domain/repositories/join_repository.dart';
+import 'package:pravo_client/features/new/domain/entities/payment_response.dart';
+
+class RequestPaymentUsecase {
+  final JoinRepository repository;
+
+  RequestPaymentUsecase(this.repository);
+
+  Future<PaymentResponse> execute(int promiseId) {
+    return repository.requestPayment(promiseId);
+  }
+}

--- a/lib/features/join/presentation/screens/join_complete_screen.dart
+++ b/lib/features/join/presentation/screens/join_complete_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+
+class JoinCompleteScreen extends StatelessWidget {
+  const JoinCompleteScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/features/join/presentation/screens/join_deposit_screen.dart
+++ b/lib/features/join/presentation/screens/join_deposit_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+
+class JoinDepositScreen extends StatelessWidget {
+  const JoinDepositScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/features/join/presentation/viewmodels/join_view_model.dart
+++ b/lib/features/join/presentation/viewmodels/join_view_model.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/join/data/repositories/join_repository_impl.dart';
+import 'package:pravo_client/features/join/domain/usecases/join_promise_usecase.dart';
+import 'package:pravo_client/features/join/domain/usecases/request_payment_usecase.dart';
+import 'package:pravo_client/features/new/domain/entities/payment_response.dart';
+
+class JoinViewModel extends StateNotifier<AsyncValue<PaymentResponse>> {
+  final JoinPromiseUseCase _joinPromiseUseCase;
+  final RequestPaymentUsecase _requestPaymentUsecase;
+
+  JoinViewModel(this._joinPromiseUseCase, this._requestPaymentUsecase)
+      : super(const AsyncValue.loading());
+
+  Future<void> joinPromiseAndRequestPayment(int promiseId) async {
+    await _joinPromiseUseCase.execute(promiseId);
+    final paymentResponse = await _requestPaymentUsecase.execute(promiseId);
+    state = AsyncValue.data(paymentResponse);
+  }
+}
+
+final joinViewModelProvider =
+    StateNotifierProvider<JoinViewModel, AsyncValue<PaymentResponse>>(
+  (ref) => JoinViewModel(
+    JoinPromiseUseCase(ref.read(joinRepositoryProvider)),
+    RequestPaymentUsecase(ref.read(joinRepositoryProvider)),
+  ),
+);

--- a/lib/features/new/data/repositories/payment_repository_impl.dart
+++ b/lib/features/new/data/repositories/payment_repository_impl.dart
@@ -44,7 +44,7 @@ class PaymentRepositoryImpl implements PaymentRepository {
     required String orderId,
     required int amount,
   }) async {
-    final response = await dio.post(
+    await dio.post(
       '/api/payment/confirm',
       data: {
         'paymentKey': paymentKey,
@@ -52,26 +52,12 @@ class PaymentRepositoryImpl implements PaymentRepository {
         'amount': amount,
       },
     );
-
-    if (response.statusCode != 200) {
-      throw Exception('Failed to confirm payment');
-    }
   }
 
   @override
   Future<void> changePromiseStatus({required int promiseId}) async {
-    try {
-      final response = await dio.post(
-        '/api/promise/$promiseId/change',
-      );
-
-      if (response.statusCode != 200) {
-        throw Exception(
-          'Failed to change promise status: ${response.statusMessage}',
-        );
-      }
-    } catch (e) {
-      throw Exception('Error while changing promise status: $e');
-    }
+    await dio.post(
+      '/api/promise/$promiseId/change',
+    );
   }
 }

--- a/lib/features/new/presentation/screens/deposit_payment_complete_screen.dart
+++ b/lib/features/new/presentation/screens/deposit_payment_complete_screen.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
+import 'package:pravo_client/features/new/presentation/viewmodels/promise_id_provider.dart';
 
-class DepositPaymentCompleteScreen extends StatelessWidget {
+class DepositPaymentCompleteScreen extends ConsumerWidget {
   const DepositPaymentCompleteScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: const Depth2AppBarWidget(
         title: '결제 완료',
@@ -56,7 +58,8 @@ class DepositPaymentCompleteScreen extends StatelessWidget {
             ),
             PrimaryButtonWidget(
               buttonText: '약속 확인하기',
-              onTap: () => context.go('/promise/1'),
+              onTap: () =>
+                  context.go('/promise/${ref.read(promiseIdProvider)}'),
               hasHorizontalMargin: true,
             ),
           ],

--- a/lib/features/new/presentation/viewmodels/deposit_payment_view_model.dart
+++ b/lib/features/new/presentation/viewmodels/deposit_payment_view_model.dart
@@ -49,8 +49,6 @@ class DepositPaymentViewModel extends StateNotifier<DepositPaymentState> {
     )
         .then((control) {
       state = state.copyWith(paymentMethodWidgetControl: control);
-    }).catchError((error) {
-      print('Error rendering payment methods: $error');
     });
 
     paymentWidget.renderAgreement(selector: 'agreement').then(
@@ -58,9 +56,7 @@ class DepositPaymentViewModel extends StateNotifier<DepositPaymentState> {
         state = state.copyWith(agreementWidgetControl: control);
         _updateAgreementStatus();
       },
-    ).catchError((error) {
-      print('Error rendering agreement: $error');
-    });
+    );
   }
 
   Future<void> _updateAgreementStatus() async {
@@ -87,19 +83,15 @@ class DepositPaymentViewModel extends StateNotifier<DepositPaymentState> {
       final paymentKey = paymentResult!.success!.paymentKey;
       final orderId = paymentResult.success!.orderId;
 
-      try {
-        await confirmPaymentUseCase.execute(
-          paymentKey: paymentKey,
-          orderId: orderId,
-          amount: ref.watch(promiseDetailsViewModelProvider).deposit!,
-        );
+      await confirmPaymentUseCase.execute(
+        paymentKey: paymentKey,
+        orderId: orderId,
+        amount: ref.watch(promiseDetailsViewModelProvider).deposit!,
+      );
 
-        await changePromiseStatusUseCase.execute(ref.read(promiseIdProvider)!);
+      await changePromiseStatusUseCase.execute(ref.read(promiseIdProvider)!);
 
-        ref.read(routerProvider).pushReplacement('/new/deposit/complete');
-      } catch (e) {
-        print('Payment confirmation failed: $e');
-      }
+      ref.read(routerProvider).pushReplacement('/new/deposit/complete');
     }
   }
 }

--- a/lib/features/promise/data/repositories/promise_repository_impl.dart
+++ b/lib/features/promise/data/repositories/promise_repository_impl.dart
@@ -2,9 +2,9 @@ import 'package:dio/dio.dart' hide Headers;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pravo_client/features/core/dio/dio_provider.dart';
 import 'package:pravo_client/features/promise/data/models/promise_model.dart';
+import 'package:pravo_client/features/promise/domain/entities/participant.dart';
 import 'package:pravo_client/features/promise/domain/entities/participant_status.dart';
 import 'package:pravo_client/features/promise/domain/entities/promise.dart';
-import 'package:pravo_client/features/promise/domain/entities/participant.dart';
 import 'package:pravo_client/features/promise/domain/repositories/promise_repository.dart';
 
 final promiseRepositoryProvider = Provider<PromiseRepository>((ref) {
@@ -26,7 +26,7 @@ class PromiseRepositoryImpl implements PromiseRepository {
     return Promise(
       id: promiseModel.id,
       name: promiseModel.name,
-      promiseDate: promiseModel.promiseDate,
+      scheduledAt: promiseModel.scheduledAt,
       location: promiseModel.location,
       status: promiseModel.status,
       deposit: promiseModel.deposit,

--- a/lib/features/promise/domain/entities/button_status.dart
+++ b/lib/features/promise/domain/entities/button_status.dart
@@ -1,7 +1,10 @@
+// ignore_for_file: constant_identifier_names
+
 enum ButtonStatus {
-  copyInvitationLink('초대 링크 복사'),
-  goToAttendanceConfirmation('참석 확인하러 가기'),
-  hidden(''); // 버튼 숨김 상태
+  COPY_INVITATION_LINK('초대 링크 복사'),
+  GO_TO_ATTENDANCE_CONFIRMATION('참석 확인하러 가기'),
+  JOIN_PROMISE('약속 참가하기'),
+  HIDDEN(''); // 버튼 숨김 상태
 
   final String text;
 
@@ -14,9 +17,9 @@ enum ButtonStatus {
 
     if (isOrganizer) {
       return timeDifferenceInMinutes <= 60
-          ? ButtonStatus.goToAttendanceConfirmation
-          : ButtonStatus.copyInvitationLink;
+          ? ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION
+          : ButtonStatus.COPY_INVITATION_LINK;
     }
-    return ButtonStatus.hidden;
+    return ButtonStatus.HIDDEN;
   }
 }

--- a/lib/features/promise/domain/entities/button_status.dart
+++ b/lib/features/promise/domain/entities/button_status.dart
@@ -10,16 +10,24 @@ enum ButtonStatus {
 
   const ButtonStatus(this.text);
 
-  static ButtonStatus getButtonStatus(bool isOrganizer, DateTime scheduledAt) {
+  static ButtonStatus getButtonStatus(
+    bool isOrganizer,
+    bool isInvitedGuest,
+    DateTime scheduledAt,
+  ) {
     final currentTime = DateTime.now();
     final timeDifferenceInMinutes =
         scheduledAt.difference(currentTime).inMinutes;
 
-    if (isOrganizer) {
-      return timeDifferenceInMinutes <= 60
+    if (timeDifferenceInMinutes <= 60) {
+      return isOrganizer
           ? ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION
-          : ButtonStatus.COPY_INVITATION_LINK;
+          : ButtonStatus.HIDDEN;
     }
+
+    if (isOrganizer) return ButtonStatus.COPY_INVITATION_LINK;
+    if (isInvitedGuest) return ButtonStatus.JOIN_PROMISE;
+
     return ButtonStatus.HIDDEN;
   }
 }

--- a/lib/features/promise/domain/entities/participant_status.dart
+++ b/lib/features/promise/domain/entities/participant_status.dart
@@ -4,7 +4,8 @@ enum ParticipantStatus {
   ATTENDED('참석'),
   CANCELED('취소'),
   NOT_ATTENDED('불참'),
-  READY('참석 예정');
+  READY('참석 예정'),
+  PENDING('대기');
 
   final String label;
 

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -30,6 +30,11 @@ class PromiseDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
+  String generateInviteLink(int promiseId) {
+    final Uri inviteUri = Uri.parse('pravo://pravo.com/promise/$promiseId');
+    return inviteUri.toString();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -97,42 +102,44 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Expanded(
-                  child: Padding(
+                  child: SingleChildScrollView(
                     padding: kScreenPadding,
-                    child: SingleChildScrollView(
-                      child: Column(
-                        children: [
-                          PromiseOverviewWidget(
-                            name: promise.name,
-                            location: promise.location,
-                            promiseDate: promise.promiseDate,
-                            organizer: promise.participants.firstWhere(
-                              (participant) => participant.role == 'ORGANIZER',
-                            ),
+                    child: Column(
+                      children: [
+                        PromiseOverviewWidget(
+                          name: promise.name,
+                          location: promise.location,
+                          promiseDate: promise.promiseDate,
+                          organizer: promise.participants.firstWhere(
+                            (participant) => participant.role == 'ORGANIZER',
                           ),
-                          ParticipantsAndStatusWidget(
-                            participants: promise.participants,
-                          ),
-                          DepositWidget(
-                            deposit: promise.deposit,
-                          ),
-                          const PromiseStatusWidget(),
-                        ],
-                      ),
+                        ),
+                        ParticipantsAndStatusWidget(
+                          participants: promise.participants,
+                        ),
+                        DepositWidget(
+                          deposit: promise.deposit,
+                        ),
+                        const PromiseStatusWidget(),
+                      ],
                     ),
                   ),
                 ),
-                if (buttonStatus != ButtonStatus.hidden)
+                if (buttonStatus != ButtonStatus.HIDDEN)
                   PrimaryButtonWidget(
                     isEnabled: true,
                     onTap: () {
-                      if (buttonStatus == ButtonStatus.copyInvitationLink) {
-                        Clipboard.setData(const ClipboardData(text: '초대 링크'));
+                      if (buttonStatus == ButtonStatus.COPY_INVITATION_LINK) {
+                        final String inviteLink =
+                            generateInviteLink(widget.promiseId);
+                        Clipboard.setData(
+                          ClipboardData(text: inviteLink),
+                        );
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
                         );
                       } else if (buttonStatus ==
-                          ButtonStatus.goToAttendanceConfirmation) {
+                          ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION) {
                         context.push(
                           '/promise/${widget.promiseId}/confirm-attendance',
                         );
@@ -141,7 +148,7 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
                     buttonColor: kPrimaryColor,
                     textColor: Colors.white,
                     buttonText: buttonStatus.text,
-                    icon: buttonStatus == ButtonStatus.copyInvitationLink
+                    icon: buttonStatus == ButtonStatus.COPY_INVITATION_LINK
                         ? PhosphorIcons.link(PhosphorIconsStyle.bold)
                         : null,
                     iconBeforeText: true,

--- a/lib/features/promise/presentation/screens/promise_detail_screen.dart
+++ b/lib/features/promise/presentation/screens/promise_detail_screen.dart
@@ -49,7 +49,7 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
         final buttonStatus = ButtonStatus.getButtonStatus(
           isOrganizer,
           isInvitedGuest,
-          promise.promiseDate,
+          promise.scheduledAt,
         );
 
         return Scaffold(
@@ -111,7 +111,7 @@ class _PromiseDetailScreenState extends ConsumerState<PromiseDetailScreen> {
                         PromiseOverviewWidget(
                           name: promise.name,
                           location: promise.location,
-                          promiseDate: promise.promiseDate,
+                          scheduledAt: promise.scheduledAt,
                           organizer: promise.participants.firstWhere(
                             (participant) => participant.role == 'ORGANIZER',
                           ),

--- a/lib/features/promise/presentation/viewmodels/promise_view_model.dart
+++ b/lib/features/promise/presentation/viewmodels/promise_view_model.dart
@@ -7,10 +7,12 @@ import 'package:pravo_client/features/promise/domain/usecases/get_promise_usecas
 class PromiseState {
   final Promise promise;
   final bool isOrganizer;
+  final bool isInvitedGuest;
 
   PromiseState({
     required this.promise,
     required this.isOrganizer,
+    required this.isInvitedGuest,
   });
 }
 
@@ -28,11 +30,15 @@ class PromiseViewModel extends StateNotifier<AsyncValue<PromiseState>> {
           participant.role == 'ORGANIZER' &&
           participant.id.toString() == memberId,
     );
+    final isInvitedGuest = !promise.participants.any(
+      (participant) => participant.id.toString() == memberId,
+    );
 
     state = AsyncValue.data(
       PromiseState(
         promise: promise,
         isOrganizer: isOrganizer,
+        isInvitedGuest: isInvitedGuest, // 초대 링크를 타고 들어온 사용자
       ),
     );
   }

--- a/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
+++ b/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
+import 'package:pravo_client/features/join/presentation/viewmodels/join_view_model.dart';
 import 'package:pravo_client/features/promise/domain/entities/button_status.dart';
 
-class PromiseActionButtonWidget extends StatelessWidget {
+class PromiseActionButtonWidget extends ConsumerStatefulWidget {
   final ButtonStatus buttonStatus;
   final int promiseId;
 
@@ -15,6 +17,13 @@ class PromiseActionButtonWidget extends StatelessWidget {
     required this.promiseId,
   });
 
+  @override
+  ConsumerState<PromiseActionButtonWidget> createState() =>
+      _PromiseActionButtonWidgetState();
+}
+
+class _PromiseActionButtonWidgetState
+    extends ConsumerState<PromiseActionButtonWidget> {
   String generateInviteLink(int promiseId) {
     final Uri inviteUri = Uri.parse('pravo://pravo.com/promise/$promiseId');
     return inviteUri.toString();
@@ -22,25 +31,37 @@ class PromiseActionButtonWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return buttonStatus != ButtonStatus.HIDDEN
+    final joinState = ref.watch(joinViewModelProvider);
+
+    joinState.when(
+      data: (paymentResponse) =>
+          context.push('/promise/${widget.promiseId}/join/deposit'),
+      error: (error, stackTrace) {},
+      loading: () {},
+    );
+
+    return widget.buttonStatus != ButtonStatus.HIDDEN
         ? PrimaryButtonWidget(
-            buttonText: buttonStatus.text,
-            onTap: () {
-              if (buttonStatus == ButtonStatus.COPY_INVITATION_LINK) {
-                final inviteLink = generateInviteLink(promiseId);
+            buttonText: widget.buttonStatus.text,
+            onTap: () async {
+              if (widget.buttonStatus == ButtonStatus.COPY_INVITATION_LINK) {
+                final inviteLink = generateInviteLink(widget.promiseId);
                 Clipboard.setData(ClipboardData(text: inviteLink));
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
                 );
-              } else if (buttonStatus ==
+              } else if (widget.buttonStatus ==
                   ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION) {
-                context.push('/promise/$promiseId/settlement/attendance');
-              } else if (buttonStatus == ButtonStatus.JOIN_PROMISE) {
-                context.push('/promise/$promiseId/join/deposit');
+                context
+                    .push('/promise/${widget.promiseId}/settlement/attendance');
+              } else if (widget.buttonStatus == ButtonStatus.JOIN_PROMISE) {
+                await ref
+                    .read(joinViewModelProvider.notifier)
+                    .joinPromiseAndRequestPayment(widget.promiseId);
               }
             },
             hasHorizontalMargin: true,
-            icon: buttonStatus == ButtonStatus.COPY_INVITATION_LINK
+            icon: widget.buttonStatus == ButtonStatus.COPY_INVITATION_LINK
                 ? PhosphorIcons.link(PhosphorIconsStyle.bold)
                 : null,
             iconBeforeText: true,

--- a/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
+++ b/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
@@ -34,8 +34,10 @@ class PromiseActionButtonWidget extends StatelessWidget {
                 );
               } else if (buttonStatus ==
                   ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION) {
-                context.push('/promise/$promiseId/confirm-attendance');
-              } else if (buttonStatus == ButtonStatus.JOIN_PROMISE) {}
+                context.push('/promise/$promiseId/settlement/attendance');
+              } else if (buttonStatus == ButtonStatus.JOIN_PROMISE) {
+                context.push('/promise/$promiseId/join/deposit');
+              }
             },
             hasHorizontalMargin: true,
             icon: buttonStatus == ButtonStatus.COPY_INVITATION_LINK

--- a/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
+++ b/lib/features/promise/presentation/widgets/promise_action_button_widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:pravo_client/features/core/presentation/widgets/primary_button_widget.dart';
+import 'package:pravo_client/features/promise/domain/entities/button_status.dart';
+
+class PromiseActionButtonWidget extends StatelessWidget {
+  final ButtonStatus buttonStatus;
+  final int promiseId;
+
+  const PromiseActionButtonWidget({
+    super.key,
+    required this.buttonStatus,
+    required this.promiseId,
+  });
+
+  String generateInviteLink(int promiseId) {
+    final Uri inviteUri = Uri.parse('pravo://pravo.com/promise/$promiseId');
+    return inviteUri.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return buttonStatus != ButtonStatus.HIDDEN
+        ? PrimaryButtonWidget(
+            buttonText: buttonStatus.text,
+            onTap: () {
+              if (buttonStatus == ButtonStatus.COPY_INVITATION_LINK) {
+                final inviteLink = generateInviteLink(promiseId);
+                Clipboard.setData(ClipboardData(text: inviteLink));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('초대 링크가 복사되었습니다.')),
+                );
+              } else if (buttonStatus ==
+                  ButtonStatus.GO_TO_ATTENDANCE_CONFIRMATION) {
+                context.push('/promise/$promiseId/confirm-attendance');
+              } else if (buttonStatus == ButtonStatus.JOIN_PROMISE) {}
+            },
+            hasHorizontalMargin: true,
+            icon: buttonStatus == ButtonStatus.COPY_INVITATION_LINK
+                ? PhosphorIcons.link(PhosphorIconsStyle.bold)
+                : null,
+            iconBeforeText: true,
+          )
+        : const SizedBox.shrink();
+  }
+}

--- a/lib/features/promises/data/repositories/promises_repository_impl.dart
+++ b/lib/features/promises/data/repositories/promises_repository_impl.dart
@@ -43,7 +43,7 @@ class PromisesRepositoryImpl implements PromisesRepository {
           (model) => Promise(
             id: model.id,
             name: model.name,
-            promiseDate: model.promiseDate,
+            scheduledAt: model.scheduledAt,
             location: model.location,
             status: model.status,
             organizerName: model.organizerName,

--- a/lib/features/promises/presentation/widgets/promise_list_widget.dart
+++ b/lib/features/promises/presentation/widgets/promise_list_widget.dart
@@ -13,28 +13,26 @@ class PromiseListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return ListView.separated(
+      key: super.key,
       padding: kScreenPadding,
-      child: ListView.separated(
-        key: super.key,
-        itemCount: promises.length,
-        itemBuilder: (context, index) {
-          final promise = promises[index];
-          return PromiseWidget(
-            promiseId: promise.id,
-            promiseName: promise.name,
-            promiseDate: promise.promiseDate,
-            location: promise.location,
-            organizerName: promise.organizerName,
-            organizerProfileImageUrl: promise.organizerProfileImageUrl,
-          );
-        },
-        separatorBuilder: (BuildContext context, int index) {
-          return const VerticalGapWidget(
-            gapHeight: 20,
-          );
-        },
-      ),
+      itemCount: promises.length,
+      itemBuilder: (context, index) {
+        final promise = promises[index];
+        return PromiseWidget(
+          promiseId: promise.id,
+          promiseName: promise.name,
+          promiseDate: promise.promiseDate,
+          location: promise.location,
+          organizerName: promise.organizerName,
+          organizerProfileImageUrl: promise.organizerProfileImageUrl,
+        );
+      },
+      separatorBuilder: (BuildContext context, int index) {
+        return const VerticalGapWidget(
+          gapHeight: 20,
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,12 +62,18 @@ class _AppState extends ConsumerState<_App> {
     final router = ref.read(routerProvider);
     final path = uri.path;
 
-    /// 약속 상세 페이지만 공유 가능하므로 promise 아닌 경우에는 홈으로 리디렉션
-    if (path.contains('/promise')) {
-      router.push(path);
-    } else {
-      router.go('/');
+    final regex = RegExp(r'^/promise/(\d+)$'); // '/promise/{promiseId}' 형식
+    final match = regex.firstMatch(path);
+
+    if (match != null) {
+      final promiseId = int.tryParse(match.group(1)!);
+      if (promiseId != null) {
+        router.push('/promise/$promiseId');
+        return;
+      }
     }
+
+    router.go('/');
   }
 
   @override


### PR DESCRIPTION
<!--
제목 앞에 아래 라벨을 추가해주세요.
 - feat: 기능 추가
 - fix: 버그 수정
 - refactor: 코드 리팩토링
 - chore: 패키지 매니저 업데이트, 빌드 관련
 - test: 테스트 코드 작성 및 수정
 - docs: 문서 업데이트
-->

## 📝 개요

<!-- 어떤 변경사항이 있는지 설명해주세요. -->

모임원 약속 참가 및 결제 요청 API 연동

## 🪐 작업 내용

<!-- 작업한 내용을 적어주세요. -->

- [x] 모임원 약속 참가: POST /api/promise/{promiseId}/join 연동
- [x] 주문 생성 & 결제 요청: POST /api/payment/request/{promiseId} 연동
- [x] 초대 링크 기능 개선: 앱 이름 'PRAVO'로 수정 및 URL 'pravo://pravo.com'으로 수정

## 🛰️ 이슈 번호

<!-- 관련된 이슈 번호를 적어주세요. -->

#71 

## 📚 참고 자료

<!-- (선택) 참고할만한 자료 및 파일이 있다면 첨부해주세요. -->
 
- 초대 링크 클릭 시 플로우는 다음과 같습니다.

| 1. URL 입력 | 2. 앱으로 이동 | 3. 약속 상세페이지 열림 |
| --- | --- | --- |
| <img width="525" alt="image" src="https://github.com/user-attachments/assets/b53e054c-be67-4e5e-aa1e-035c73db514d"> | <img width="525" alt="image" src="https://github.com/user-attachments/assets/50e3f4ee-c001-4ddc-b4d6-893cf81e5f96"> | <img width="525" alt="image" src="https://github.com/user-attachments/assets/6bf5674d-5973-4f68-b136-b4390c17c465"> |



