### PR TITLE
chore: apk 릴리즈를 위한 설정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,6 @@ plugins {
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 
-
 android {
     namespace = "com.pravo.pravo_client"
     compileSdk = flutter.compileSdkVersion
@@ -22,7 +21,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.pravo.pravo_client"
         minSdkVersion flutter.minSdkVersion
         minSdk = flutter.minSdkVersion
@@ -33,11 +31,18 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            // ProGuard 설정이 없으면 추가
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+dependencies {
+    implementation 'com.google.errorprone:error_prone_annotations:2.11.0'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 flutter {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,12 @@ plugins {
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "com.pravo.pravo_client"
     compileSdk = flutter.compileSdkVersion
@@ -29,9 +35,18 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+       release {
+           keyAlias keystoreProperties['keyAlias']
+           keyPassword keystoreProperties['keyPassword']
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+           storePassword keystoreProperties['storePassword']
+       }
+   }
+
     buildTypes {
         release {
-            signingConfig = signingConfigs.debug
+            signingConfig signingConfigs.release
             // ProGuard 설정이 없으면 추가
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/lib/features/auth/presentation/widgets/apple_login_button_widget.dart
+++ b/lib/features/auth/presentation/widgets/apple_login_button_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pravo_client/features/auth/data/models/platform.dart';
 import 'package:pravo_client/features/auth/presentation/viewmodels/auth_provider.dart';
@@ -39,6 +40,12 @@ class AppleLoginButtonWidget extends ConsumerWidget {
             AppleIDAuthorizationScopes.email,
             AppleIDAuthorizationScopes.fullName,
           ],
+          webAuthenticationOptions: WebAuthenticationOptions(
+            clientId: 'pravoClient.pravo.com',
+            redirectUri: Uri.parse(
+              dotenv.env['APPLE_WEB_AUTHENTICATION_REDIRECT_URI']!,
+            ),
+          ),
         );
 
         await handleLoginSuccess(credential.identityToken!);


### PR DESCRIPTION
## 📝 개요
apk 릴리즈를 위한 설정 추가 

## 🪐 작업 내용
- [] 빌드 자체가 안 되던 문제 해결을 위해 8c216540933e3fb8bc0bf545515db445d49f9c56 진행
- [] 카카오 로그인 안 되던 이슈 (릴리즈용 키가 없어서 생성 후 카카오 어플리케이션에 설정) 해결을 위해 f6cbfa26829e102bc2f71655ec56a7d5090d44dc 진행
- [] 애플 로그인 안 되던 이슈 (웹 로그인 활성화 필요) 해결을 위해 011a0e5f313e5eebbc80f21d2301f9fd8a8ec893 진행

## 🛰️ 이슈 번호

## 📚 참고 자료
`APPLE_WEB_AUTHENTICATION_REDIRECT_URI` 는 노션 Secrets에 추가해두었습니다 !!