### PR TITLE
feat: 프로필 수정 API 연동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
     <!-- 인터넷 사용 권한 설정-->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- 이미지 사용 권한 설정-->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
     <application
         android:label="pravo_client"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,11 @@ PODS:
   - app_links (0.0.2):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_image_compress_common (1.0.0):
+    - Flutter
+    - Mantle
+    - SDWebImage
+    - SDWebImageWebPCoder
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
     - flutter_inappwebview_ios/Core (= 0.0.1)
@@ -17,6 +22,21 @@ PODS:
     - Flutter
   - kakao_flutter_sdk_common (1.9.6):
     - Flutter
+  - libwebp (1.3.2):
+    - libwebp/demux (= 1.3.2)
+    - libwebp/mux (= 1.3.2)
+    - libwebp/sharpyuv (= 1.3.2)
+    - libwebp/webp (= 1.3.2)
+  - libwebp/demux (1.3.2):
+    - libwebp/webp
+  - libwebp/mux (1.3.2):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.3.2)
+  - libwebp/webp (1.3.2):
+    - libwebp/sharpyuv
+  - Mantle (2.2.0):
+    - Mantle/extobjc (= 2.2.0)
+  - Mantle/extobjc (2.2.0)
   - OrderedSet (6.0.3)
   - os_info_plugin (0.0.1):
     - Flutter
@@ -25,6 +45,12 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - SDWebImage (5.20.0):
+    - SDWebImage/Core (= 5.20.0)
+  - SDWebImage/Core (5.20.0)
+  - SDWebImageWebPCoder (0.14.6):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.40.1)
   - sentry_flutter (8.10.1):
     - Flutter
@@ -46,6 +72,7 @@ PODS:
 DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - Flutter (from `Flutter`)
+  - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
@@ -63,7 +90,11 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - libwebp
+    - Mantle
     - OrderedSet
+    - SDWebImage
+    - SDWebImageWebPCoder
     - Sentry
 
 EXTERNAL SOURCES:
@@ -71,6 +102,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/app_links/ios"
   Flutter:
     :path: Flutter
+  flutter_image_compress_common:
+    :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_inappwebview_ios:
     :path: ".symlinks/plugins/flutter_inappwebview_ios/ios"
   flutter_native_splash:
@@ -103,15 +136,20 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_links: e7a6750a915a9e161c58d91bc610e8cd1d4d0ad0
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   kakao_flutter_sdk_common: 4f10f98226da5d0f7cbdeeaed5cc21f144515209
+  libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
+  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   os_info_plugin: d89ddf87e910a0d598fc4fc69d2b8f0f8239314f
   package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
+  SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: e9215d7b17f7902692b4f8700e061e4f853e3521
   sentry_flutter: 927eed60d66951d1b0f1db37fe94ff5cb7c80231
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -13,6 +13,8 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - image_picker_ios (0.0.1):
+    - Flutter
   - kakao_flutter_sdk_common (1.9.6):
     - Flutter
   - OrderedSet (6.0.3)
@@ -47,6 +49,7 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - os_info_plugin (from `.symlinks/plugins/os_info_plugin/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -74,6 +77,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   kakao_flutter_sdk_common:
     :path: ".symlinks/plugins/kakao_flutter_sdk_common/ios"
   os_info_plugin:
@@ -101,6 +106,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   kakao_flutter_sdk_common: 4f10f98226da5d0f7cbdeeaed5cc21f144515209
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   os_info_plugin: d89ddf87e910a0d598fc4fc69d2b8f0f8239314f

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -72,5 +72,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs permission to access photos on your device</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs permission to access photos on your device</string>
 </dict>
 </plist>

--- a/lib/features/member/data/repositories/member_repository_impl.dart
+++ b/lib/features/member/data/repositories/member_repository_impl.dart
@@ -20,4 +20,20 @@ class MemberRepositoryImpl implements MemberRepository {
     final memberDto = MemberModel.fromJson(response.data);
     return memberDto.toEntity(memberId);
   }
+
+  @override
+  Future<void> editMember({
+    required String name,
+    MultipartFile? file,
+    required bool resetToDefaultImage,
+  }) async {
+    await dio.patch(
+      '/api/member/profile',
+      data: {
+        name,
+        file,
+        resetToDefaultImage,
+      },
+    );
+  }
 }

--- a/lib/features/member/data/repositories/member_repository_impl.dart
+++ b/lib/features/member/data/repositories/member_repository_impl.dart
@@ -27,13 +27,20 @@ class MemberRepositoryImpl implements MemberRepository {
     MultipartFile? file,
     required bool resetToDefaultImage,
   }) async {
+    final data = FormData.fromMap({
+      'name': name,
+      if (file != null) 'file': file,
+      'resetToDefaultImage': resetToDefaultImage,
+    });
+
     await dio.patch(
       '/api/member/profile',
-      data: {
-        name,
-        file,
-        resetToDefaultImage,
-      },
+      data: data,
+      options: Options(
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      ),
     );
   }
 }

--- a/lib/features/member/domain/repositories/member_repository.dart
+++ b/lib/features/member/domain/repositories/member_repository.dart
@@ -1,5 +1,11 @@
+import 'package:dio/dio.dart';
 import 'package:pravo_client/features/member/domain/entities/member.dart';
 
 abstract class MemberRepository {
   Future<Member> getMember(int id);
+  Future<void> editMember({
+    required String name,
+    MultipartFile? file,
+    required bool resetToDefaultImage,
+  });
 }

--- a/lib/features/member/domain/usecases/edit_member_usecase.dart
+++ b/lib/features/member/domain/usecases/edit_member_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
+
+class EditMemberUseCase {
+  final MemberRepository repository;
+
+  EditMemberUseCase(this.repository);
+
+  Future<void> editMember({
+    required String name,
+    MultipartFile? file,
+    required bool resetToDefaultImage,
+  }) {
+    return repository.editMember(
+      name: name,
+      file: file,
+      resetToDefaultImage: resetToDefaultImage,
+    );
+  }
+}

--- a/lib/features/member/domain/usecases/edit_member_usecase.dart
+++ b/lib/features/member/domain/usecases/edit_member_usecase.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
 
 class EditMemberUseCase {
@@ -8,12 +12,26 @@ class EditMemberUseCase {
 
   Future<void> editMember({
     required String name,
-    MultipartFile? file,
+    File? file,
     required bool resetToDefaultImage,
-  }) {
+  }) async {
+    if (file != null) {
+      final mimeType = lookupMimeType(file.path) ?? 'application/octet-stream';
+      final mimeTypeSplit = mimeType.split('/');
+      final profileImageFile = await MultipartFile.fromFile(
+        file.path,
+        filename: file.path.split('/').last,
+        contentType: MediaType(mimeTypeSplit[0], mimeTypeSplit[1]),
+      );
+      return repository.editMember(
+        name: name,
+        file: profileImageFile,
+        resetToDefaultImage: resetToDefaultImage,
+      );
+    }
+
     return repository.editMember(
       name: name,
-      file: file,
       resetToDefaultImage: resetToDefaultImage,
     );
   }

--- a/lib/features/member/domain/usecases/edit_member_usecase.dart
+++ b/lib/features/member/domain/usecases/edit_member_usecase.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:mime/mime.dart';
+import 'package:uuid/uuid.dart';
 import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
 
 class EditMemberUseCase {
@@ -16,13 +18,17 @@ class EditMemberUseCase {
     required bool resetToDefaultImage,
   }) async {
     if (file != null) {
-      final mimeType = lookupMimeType(file.path) ?? 'application/octet-stream';
+      final compressedFile = await _convertAndCompressToJpeg(file);
+
+      final mimeType =
+          lookupMimeType(compressedFile.path) ?? 'application/octet-stream';
       final mimeTypeSplit = mimeType.split('/');
       final profileImageFile = await MultipartFile.fromFile(
-        file.path,
-        filename: file.path.split('/').last,
+        compressedFile.path,
+        filename: compressedFile.path.split('/').last,
         contentType: MediaType(mimeTypeSplit[0], mimeTypeSplit[1]),
       );
+
       return repository.editMember(
         name: name,
         file: profileImageFile,
@@ -34,5 +40,26 @@ class EditMemberUseCase {
       name: name,
       resetToDefaultImage: resetToDefaultImage,
     );
+  }
+
+  Future<File> _convertAndCompressToJpeg(File file) async {
+    const uuid = Uuid();
+    File compressedFile = file;
+    int quality = 85;
+
+    do {
+      final targetPath = '${file.parent.path}/compressed_${uuid.v4()}.jpg';
+      final compressedXFile = await FlutterImageCompress.compressAndGetFile(
+        compressedFile.path,
+        targetPath,
+        format: CompressFormat.jpeg,
+        quality: quality,
+      );
+      compressedFile = File(compressedXFile!.path);
+      quality -= 5;
+    } while (compressedFile.lengthSync() >
+        1024 * 1024); // FIXME: 추후 서버 nginx 문제가 해결되면 1MB보다 큰 값으로 수정 필요함
+
+    return compressedFile;
   }
 }

--- a/lib/features/setting/presentation/screens/profile_edit_screen.dart
+++ b/lib/features/setting/presentation/screens/profile_edit_screen.dart
@@ -1,10 +1,9 @@
-import 'package:dio/dio.dart';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
-import 'package:http_parser/http_parser.dart';
-import 'package:mime/mime.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/text_field_error_message_widget.dart';
@@ -24,7 +23,7 @@ class ProfileEditScreen extends ConsumerWidget {
     final editMemberNotifier = ref.read(editMemberViewModelProvider.notifier);
 
     String name = member.name;
-    MultipartFile? profileImageFile;
+    File? profileImageFile;
     bool resetToDefaultImage = false;
 
     ref.listen<AsyncValue<void>>(editMemberViewModelProvider, (previous, next) {
@@ -59,14 +58,7 @@ class ProfileEditScreen extends ConsumerWidget {
             ProfileImageEditWidget(
               profileImageUrl: member.profileImageUrl,
               onImageSelected: (file) async {
-                final mimeType =
-                    lookupMimeType(file.path) ?? 'application/octet-stream';
-                final mimeTypeSplit = mimeType.split('/');
-                profileImageFile = await MultipartFile.fromFile(
-                  file.path,
-                  filename: file.path.split('/').last,
-                  contentType: MediaType(mimeTypeSplit[0], mimeTypeSplit[1]),
-                );
+                profileImageFile = file;
                 resetToDefaultImage = false;
               },
               onResetToDefault: () {

--- a/lib/features/setting/presentation/screens/profile_edit_screen.dart
+++ b/lib/features/setting/presentation/screens/profile_edit_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/text_field_error_message_widget.dart';
@@ -57,9 +59,13 @@ class ProfileEditScreen extends ConsumerWidget {
             ProfileImageEditWidget(
               profileImageUrl: member.profileImageUrl,
               onImageSelected: (file) async {
+                final mimeType =
+                    lookupMimeType(file.path) ?? 'application/octet-stream';
+                final mimeTypeSplit = mimeType.split('/');
                 profileImageFile = await MultipartFile.fromFile(
                   file.path,
-                  filename: file.path.split('/').last, // 파일 이름
+                  filename: file.path.split('/').last,
+                  contentType: MediaType(mimeTypeSplit[0], mimeTypeSplit[1]),
                 );
                 resetToDefaultImage = false;
               },

--- a/lib/features/setting/presentation/screens/profile_edit_screen.dart
+++ b/lib/features/setting/presentation/screens/profile_edit_screen.dart
@@ -57,13 +57,9 @@ class ProfileEditScreen extends ConsumerWidget {
           children: [
             ProfileImageEditWidget(
               profileImageUrl: member.profileImageUrl,
-              onImageSelected: (file) async {
+              onImageChanged: (file, resetToDefault) {
                 profileImageFile = file;
-                resetToDefaultImage = false;
-              },
-              onResetToDefault: () {
-                profileImageFile = null;
-                resetToDefaultImage = true;
+                resetToDefaultImage = resetToDefault;
               },
             ),
             const SizedBox(

--- a/lib/features/setting/presentation/screens/profile_edit_screen.dart
+++ b/lib/features/setting/presentation/screens/profile_edit_screen.dart
@@ -1,23 +1,48 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth2_app_bar_widget.dart';
+import 'package:pravo_client/features/core/presentation/widgets/text_field_error_message_widget.dart';
 import 'package:pravo_client/features/member/domain/entities/member.dart';
+import 'package:pravo_client/features/setting/presentation/viewmodels/edit_member_view_model.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/nickname_edit_widget.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/profile_image_edit_widget.dart';
 
-class ProfileEditScreen extends StatelessWidget {
+class ProfileEditScreen extends ConsumerWidget {
   final Member member;
+
   const ProfileEditScreen({super.key, required this.member});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final editMemberViewModel = ref.watch(editMemberViewModelProvider);
+    final editMemberNotifier = ref.read(editMemberViewModelProvider.notifier);
+
+    String name = member.name;
+    MultipartFile? profileImageFile;
+    bool resetToDefaultImage = false;
+
+    ref.listen<AsyncValue<void>>(editMemberViewModelProvider, (previous, next) {
+      if (next is AsyncData) {
+        if (context.mounted) {
+          context.pushReplacement('/setting');
+        }
+      }
+    });
+
     return Scaffold(
       appBar: Depth2AppBarWidget(
         title: '프로필 설정',
         actionIconText: '완료',
-        actionOnPressed: () {
-          Navigator.pop(context);
+        actionOnPressed: () async {
+          await editMemberNotifier.editMember(
+            name: name,
+            file: profileImageFile,
+            resetToDefaultImage: resetToDefaultImage,
+          );
         },
         leadingIcon: PhosphorIcons.caretLeft(),
         leadingOnPressed: () {
@@ -31,11 +56,37 @@ class ProfileEditScreen extends StatelessWidget {
           children: [
             ProfileImageEditWidget(
               profileImageUrl: member.profileImageUrl,
+              onImageSelected: (file) async {
+                profileImageFile = await MultipartFile.fromFile(
+                  file.path,
+                  filename: file.path.split('/').last, // 파일 이름
+                );
+                resetToDefaultImage = false;
+              },
+              onResetToDefault: () {
+                profileImageFile = null;
+                resetToDefaultImage = true;
+              },
             ),
             const SizedBox(
               height: 50,
             ),
-            NicknameEditWidget(name: member.name),
+            NicknameEditWidget(
+              name: member.name,
+              onNameChanged: (newName) {
+                name = newName;
+              },
+            ),
+            const SizedBox(
+              height: 8,
+            ),
+            editMemberViewModel.when(
+              data: (_) => const SizedBox.shrink(),
+              loading: () => const SizedBox.shrink(),
+              error: (error, _) => TextFieldErrorMessageWidget(
+                title: editMemberNotifier.errorMessage!,
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/features/setting/presentation/screens/setting_screen.dart
+++ b/lib/features/setting/presentation/screens/setting_screen.dart
@@ -4,7 +4,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:pravo_client/assets/constants.dart';
 import 'package:pravo_client/features/core/presentation/widgets/depth1_app_bar_widget.dart';
 import 'package:pravo_client/features/core/presentation/widgets/navigation_bar_widget.dart';
-import 'package:pravo_client/features/setting/presentation/viewmodels/member_view_model.dart';
+import 'package:pravo_client/features/setting/presentation/viewmodels/get_member_view_model.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/profile_preview_widget.dart';
 import 'package:pravo_client/features/setting/presentation/widgets/text_buttons_widget.dart';
 
@@ -20,13 +20,13 @@ class _SettingScreenState extends ConsumerState<SettingScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(memberViewModelProvider.notifier).getMember();
+      ref.read(getMemberViewModelProvider.notifier).getMember();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final memberState = ref.watch(memberViewModelProvider);
+    final memberState = ref.watch(getMemberViewModelProvider);
 
     return Scaffold(
       appBar: Depth1AppBarWidget(

--- a/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
+++ b/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pravo_client/features/member/data/repositories/member_repository_impl.dart';
@@ -20,7 +22,7 @@ class EditMemberViewModel extends StateNotifier<AsyncValue<void>> {
 
   Future<void> editMember({
     required String name,
-    MultipartFile? file,
+    File? file,
     required bool resetToDefaultImage,
   }) async {
     state = const AsyncValue.loading();

--- a/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
+++ b/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
@@ -1,0 +1,46 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pravo_client/features/member/data/repositories/member_repository_impl.dart';
+import 'package:pravo_client/features/member/domain/usecases/edit_member_usecase.dart';
+
+final editMemberViewModelProvider =
+    StateNotifierProvider<EditMemberViewModel, AsyncValue<void>>((ref) {
+  return EditMemberViewModel(
+    editMemberUseCase: EditMemberUseCase(ref.watch(memberRepositoryProvider)),
+  );
+});
+
+class EditMemberViewModel extends StateNotifier<AsyncValue<void>> {
+  final EditMemberUseCase editMemberUseCase;
+  String? errorMessage;
+
+  EditMemberViewModel({
+    required this.editMemberUseCase,
+  }) : super(const AsyncValue.loading());
+
+  Future<void> editMember({
+    required String name,
+    MultipartFile? file,
+    required bool resetToDefaultImage,
+  }) async {
+    state = const AsyncValue.loading();
+    errorMessage = null;
+
+    try {
+      await editMemberUseCase.editMember(
+        name: name,
+        file: file,
+        resetToDefaultImage: resetToDefaultImage,
+      );
+
+      state = const AsyncValue.data(null);
+    } on DioException catch (e, st) {
+      if (e.response?.data['code'] == 'E09') {
+        errorMessage = '이미 사용 중인 닉네임이에요.';
+      } else {
+        errorMessage = '프로필 수정 중 문제가 발생했습니다.';
+      }
+      state = AsyncValue.error(e, st);
+    }
+  }
+}

--- a/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
+++ b/lib/features/setting/presentation/viewmodels/edit_member_view_model.dart
@@ -37,6 +37,8 @@ class EditMemberViewModel extends StateNotifier<AsyncValue<void>> {
     } on DioException catch (e, st) {
       if (e.response?.data['code'] == 'E09') {
         errorMessage = '이미 사용 중인 닉네임이에요.';
+      } else if (e.response?.data['code'] == 'E07') {
+        errorMessage = '이미지 확장자는 jpg, png, webp만 가능합니다.';
       } else {
         errorMessage = '프로필 수정 중 문제가 발생했습니다.';
       }

--- a/lib/features/setting/presentation/viewmodels/get_member_view_model.dart
+++ b/lib/features/setting/presentation/viewmodels/get_member_view_model.dart
@@ -2,19 +2,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pravo_client/features/member/data/repositories/member_repository_impl.dart';
 import 'package:pravo_client/features/member/domain/entities/member.dart';
-import 'package:pravo_client/features/member/domain/repositories/member_repository.dart';
+import 'package:pravo_client/features/member/domain/usecases/get_member_usecase.dart';
 
-final memberViewModelProvider =
-    StateNotifierProvider<MemberViewModel, AsyncValue<Member>>((ref) {
-  return MemberViewModel(memberRepository: ref.watch(memberRepositoryProvider));
+final getMemberViewModelProvider =
+    StateNotifierProvider<GetMemberViewModel, AsyncValue<Member>>((ref) {
+  return GetMemberViewModel(
+    getMemberUseCase: GetMemberUseCase(ref.watch(memberRepositoryProvider)),
+  );
 });
 
-class MemberViewModel extends StateNotifier<AsyncValue<Member>> {
-  final MemberRepository memberRepository;
+class GetMemberViewModel extends StateNotifier<AsyncValue<Member>> {
+  final GetMemberUseCase getMemberUseCase;
   final _secureStorage = const FlutterSecureStorage();
 
-  MemberViewModel({
-    required this.memberRepository,
+  GetMemberViewModel({
+    required this.getMemberUseCase,
   }) : super(const AsyncValue.loading());
 
   Future<void> getMember() async {
@@ -26,7 +28,7 @@ class MemberViewModel extends StateNotifier<AsyncValue<Member>> {
       );
       return;
     }
-    final member = await memberRepository.getMember(int.parse(memberId));
+    final member = await getMemberUseCase.getMember(int.parse(memberId));
     state = AsyncValue.data(member);
   }
 }

--- a/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
+++ b/lib/features/setting/presentation/widgets/nickname_edit_widget.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:pravo_client/assets/constants.dart';
-import 'package:pravo_client/features/core/presentation/widgets/text_field_error_message_widget.dart';
 
 class NicknameEditWidget extends StatelessWidget {
   final String name;
+  final ValueChanged<String> onNameChanged;
   const NicknameEditWidget({
     super.key,
     required this.name,
+    required this.onNameChanged,
   });
 
   @override
@@ -31,13 +32,7 @@ class NicknameEditWidget extends StatelessWidget {
           style: const TextStyle(
             fontSize: kInputTextFontSize,
           ),
-        ),
-        const SizedBox(
-          height: 8,
-        ),
-        const TextFieldErrorMessageWidget(
-          // FIXME: 프로필 수정 API가 개발 완료되면, 프로필 수정 API의 호출 결과에 따라 노출하도록 수정할 것
-          title: '이미 사용 중인 닉네임이에요. 다른 닉네임을 골라볼까요?',
+          onChanged: onNameChanged,
         ),
       ],
     );

--- a/lib/features/setting/presentation/widgets/profile_image_edit_widget.dart
+++ b/lib/features/setting/presentation/widgets/profile_image_edit_widget.dart
@@ -1,12 +1,33 @@
+import 'dart:io';
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:pravo_client/assets/constants.dart';
 
 class ProfileImageEditWidget extends StatelessWidget {
   final String? profileImageUrl;
+  final void Function(File file) onImageSelected;
+  final VoidCallback onResetToDefault;
+
   const ProfileImageEditWidget({
     super.key,
     this.profileImageUrl,
+    required this.onImageSelected,
+    required this.onResetToDefault,
   });
+
+  Future<void> _pickImage(BuildContext context) async {
+    final picker = ImagePicker();
+    try {
+      final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+      if (pickedFile != null) {
+        onImageSelected(File(pickedFile.path));
+      }
+    } catch (e) {
+      log(e.toString(), error: e);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,25 +51,35 @@ class ProfileImageEditWidget extends StatelessWidget {
           Positioned(
             bottom: 2,
             right: -2,
-            child: Container(
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                shape: BoxShape.circle,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.white,
-                    spreadRadius: 1,
-                  ),
-                ],
-              ),
-              child: GestureDetector(
-                onTap: () {},
+            child: PopupMenuButton<int>(
+              onSelected: (value) {
+                if (value == 1) {
+                  _pickImage(context);
+                } else if (value == 2) {
+                  onResetToDefault();
+                }
+              },
+              icon: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  shape: BoxShape.circle,
+                ),
                 child: const Icon(
                   Icons.add_circle_rounded,
                   color: kPrimaryColor,
                   size: 28,
                 ),
               ),
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 1,
+                  child: Text('갤러리에서 사진 선택'),
+                ),
+                const PopupMenuItem(
+                  value: 2,
+                  child: Text('기본 이미지 적용'),
+                ),
+              ],
             ),
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -659,7 +659,7 @@ packages:
     source: hosted
     version: "3.2.1"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
@@ -915,7 +915,7 @@ packages:
     source: hosted
     version: "1.15.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -403,6 +403,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.1"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "45a3071868092a61b11044c70422b04d39d4d9f2ef536f3c5b11fb65a1e7dd90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: "7f79bc6c8a363063620b4e372fa86bc691e1cb28e58048cd38e030692fbd99ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "26df6385512e92b3789dc76b613b54b55c457a7f1532e59078b04bf189782d47"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: f02fe352b17f82b72f481de45add240db062a2585850bea1667e82cc4cd6c311
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4+1"
   flutter_inappwebview:
     dependency: transitive
     description:
@@ -1432,7 +1480,7 @@ packages:
     source: hosted
     version: "3.1.3"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -238,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -342,6 +350,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
   fixnum:
     dependency: transitive
     description:
@@ -448,6 +488,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.23"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -626,6 +674,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: fa8141602fde3f7e2f81dbf043613eb44dfa325fa0bcf93c0f142c9f7a2c193e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+18"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "4f0568120c6fcc0aaa04511cb9f9f4d29fc3d0139884b1d06be88dcec7641d6b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+1"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   app_links: ^6.3.2
   dio: ^5.7.0
   sentry_flutter: ^8.10.1
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,8 @@ dependencies:
   image_picker: ^1.1.2
   mime: ^2.0.0
   http_parser: ^4.0.2
+  flutter_image_compress: ^2.3.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   dio: ^5.7.0
   sentry_flutter: ^8.10.1
   image_picker: ^1.1.2
+  mime: ^2.0.0
+  http_parser: ^4.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📝 개요
프로필 수정 API 연동

## 🪐 작업 내용
- [ ] 프로필 수정 API 연동
- [ ] Get & Edit MemberUseCase를 분리

## 🛰️ 이슈 번호
#79
 
## 📚 참고 자료
- 프로필 수정 버튼 클릭 시, 사용자 갤러리에서 이미지를 가져온 뒤, 1MB(늘릴 예정) 이하로 압축한 뒤 서버로 전송합니다.
- 닉네임 중복 에러코드가 올 때만 에러 텍스트 메시지를 보여줍니다.

![image](https://github.com/user-attachments/assets/7d691e24-4599-4da7-a11b-05e032978b4d)
![image](https://github.com/user-attachments/assets/6ad4a65e-1c4b-4710-99da-3dce6b007b9a)
![image](https://github.com/user-attachments/assets/8846cc8b-8e58-4afd-aeb9-f78b247bd4db)
![image](https://github.com/user-attachments/assets/a6a80c97-c80d-4ef9-944a-812f79272979)
